### PR TITLE
Add test suite with 85 tests across all features

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,14 +15,30 @@ let package = Package(
         )
     ],
     targets: [
-        .executableTarget(
-            name: "JobApplicationWizard",
+        .target(
+            name: "JobApplicationWizardCore",
             dependencies: [
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "Sparkle", package: "Sparkle")
             ],
-            path: "Sources/JobApplicationWizard",
+            path: "Sources/JobApplicationWizardCore",
             resources: [.process("Resources")]
+        ),
+        .executableTarget(
+            name: "JobApplicationWizard",
+            dependencies: [
+                "JobApplicationWizardCore",
+                .product(name: "Sparkle", package: "Sparkle")
+            ],
+            path: "Sources/JobApplicationWizard"
+        ),
+        .testTarget(
+            name: "JobApplicationWizardTests",
+            dependencies: [
+                "JobApplicationWizardCore",
+                .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
+            ],
+            path: "Tests/JobApplicationWizardTests"
         )
     ]
 )

--- a/Sources/JobApplicationWizard/App.swift
+++ b/Sources/JobApplicationWizard/App.swift
@@ -4,6 +4,7 @@ import AppKit
 import SwiftUI
 import ComposableArchitecture
 import Sparkle
+import JobApplicationWizardCore
 
 #if os(macOS)
 class AppDelegate: NSObject, NSApplicationDelegate {

--- a/Sources/JobApplicationWizardCore/AddJobView.swift
+++ b/Sources/JobApplicationWizardCore/AddJobView.swift
@@ -1,11 +1,15 @@
 import SwiftUI
 import ComposableArchitecture
 
-struct AddJobView: View {
+public struct AddJobView: View {
     @Bindable var store: StoreOf<AddJobFeature>
     @Environment(\.dismiss) private var dismiss
 
-    var body: some View {
+    public init(store: StoreOf<AddJobFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
         VStack(spacing: 0) {
             HStack {
                 Text("New Job Application")

--- a/Sources/JobApplicationWizardCore/ContentView.swift
+++ b/Sources/JobApplicationWizardCore/ContentView.swift
@@ -1,11 +1,15 @@
 import SwiftUI
 import ComposableArchitecture
 
-struct ContentView: View {
+public struct ContentView: View {
     @Bindable var store: StoreOf<AppFeature>
     @Environment(\.openWindow) private var openWindow
 
-    var body: some View {
+    public init(store: StoreOf<AppFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
         NavigationSplitView(columnVisibility: .constant(.all)) {
             SidebarView(store: store)
                 .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 280)

--- a/Sources/JobApplicationWizardCore/Dependencies/ClaudeClient.swift
+++ b/Sources/JobApplicationWizardCore/Dependencies/ClaudeClient.swift
@@ -3,29 +3,40 @@ import ComposableArchitecture
 
 // MARK: - Token Usage
 
-struct AITokenUsage: Equatable {
-    let inputTokens: Int
-    let outputTokens: Int
+public struct AITokenUsage: Equatable {
+    public let inputTokens: Int
+    public let outputTokens: Int
 
-    static let zero = AITokenUsage(inputTokens: 0, outputTokens: 0)
+    public static let zero = AITokenUsage(inputTokens: 0, outputTokens: 0)
+
+    public init(inputTokens: Int, outputTokens: Int) {
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+    }
 
     /// Estimated cost in USD using claude-sonnet-4-6 pricing ($3/MTok in, $15/MTok out)
-    var estimatedCost: Double {
+    public var estimatedCost: Double {
         Double(inputTokens) * 3.0 / 1_000_000 + Double(outputTokens) * 15.0 / 1_000_000
     }
 
-    var totalTokens: Int { inputTokens + outputTokens }
+    public var totalTokens: Int { inputTokens + outputTokens }
 }
 
 // MARK: - ClaudeClient
 
-struct ClaudeClient {
-    var chat: @Sendable (String, String, [ChatMessage]) async throws -> (String, AITokenUsage)
+public struct ClaudeClient {
+    public var chat: @Sendable (String, String, [ChatMessage]) async throws -> (String, AITokenUsage)
     // (apiKey, systemPrompt, messageHistory) -> (responseText, usage)
+
+    public init(
+        chat: @escaping @Sendable (String, String, [ChatMessage]) async throws -> (String, AITokenUsage)
+    ) {
+        self.chat = chat
+    }
 }
 
 extension ClaudeClient: DependencyKey {
-    static var liveValue: ClaudeClient {
+    public static var liveValue: ClaudeClient {
         ClaudeClient(
             chat: { apiKey, systemPrompt, history in
                 let messages = history.map { msg -> [String: String] in
@@ -85,12 +96,12 @@ private struct ClaudeResponse: Decodable {
     let usage: Usage
 }
 
-enum AIError: LocalizedError {
+public enum AIError: LocalizedError {
     case noAPIKey
     case invalidResponse
     case apiError(Int, String)
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .noAPIKey: return "No Claude API key. Add it in Settings."
         case .invalidResponse: return "Invalid response from Claude API."
@@ -99,8 +110,14 @@ enum AIError: LocalizedError {
     }
 }
 
+extension ClaudeClient: TestDependencyKey {
+    public static let testValue = ClaudeClient(
+        chat: unimplemented("\(Self.self).chat")
+    )
+}
+
 extension DependencyValues {
-    var claudeClient: ClaudeClient {
+    public var claudeClient: ClaudeClient {
         get { self[ClaudeClient.self] }
         set { self[ClaudeClient.self] = newValue }
     }

--- a/Sources/JobApplicationWizardCore/Dependencies/KeychainClient.swift
+++ b/Sources/JobApplicationWizardCore/Dependencies/KeychainClient.swift
@@ -5,13 +5,21 @@ import ComposableArchitecture
 private let service = "com.zsparks.jobapplicationwizard"
 private let account = "claude-api-key"
 
-struct KeychainClient {
-    var loadAPIKey: @Sendable () -> String
-    var saveAPIKey: @Sendable (String) -> Void
+public struct KeychainClient {
+    public var loadAPIKey: @Sendable () -> String
+    public var saveAPIKey: @Sendable (String) -> Void
+
+    public init(
+        loadAPIKey: @escaping @Sendable () -> String,
+        saveAPIKey: @escaping @Sendable (String) -> Void
+    ) {
+        self.loadAPIKey = loadAPIKey
+        self.saveAPIKey = saveAPIKey
+    }
 }
 
 extension KeychainClient: DependencyKey {
-    static var liveValue: KeychainClient {
+    public static var liveValue: KeychainClient {
         KeychainClient(
             loadAPIKey: {
                 let query: [CFString: Any] = [
@@ -50,8 +58,15 @@ extension KeychainClient: DependencyKey {
     }
 }
 
+extension KeychainClient: TestDependencyKey {
+    public static let testValue = KeychainClient(
+        loadAPIKey: unimplemented("\(Self.self).loadAPIKey"),
+        saveAPIKey: unimplemented("\(Self.self).saveAPIKey")
+    )
+}
+
 extension DependencyValues {
-    var keychainClient: KeychainClient {
+    public var keychainClient: KeychainClient {
         get { self[KeychainClient.self] }
         set { self[KeychainClient.self] = newValue }
     }

--- a/Sources/JobApplicationWizardCore/Dependencies/PDFClient.swift
+++ b/Sources/JobApplicationWizardCore/Dependencies/PDFClient.swift
@@ -4,14 +4,24 @@ import ComposableArchitecture
 
 // MARK: - PDFClient
 
-struct PDFClient {
-    var printJobDescription: @Sendable (JobApplication) async -> Void
-    var generateAndSavePDF: @Sendable (JobApplication) async throws -> String  // returns saved path
-    var openPDF: @Sendable (String) async -> Void
+public struct PDFClient {
+    public var printJobDescription: @Sendable (JobApplication) async -> Void
+    public var generateAndSavePDF: @Sendable (JobApplication) async throws -> String  // returns saved path
+    public var openPDF: @Sendable (String) async -> Void
+
+    public init(
+        printJobDescription: @escaping @Sendable (JobApplication) async -> Void,
+        generateAndSavePDF: @escaping @Sendable (JobApplication) async throws -> String,
+        openPDF: @escaping @Sendable (String) async -> Void
+    ) {
+        self.printJobDescription = printJobDescription
+        self.generateAndSavePDF = generateAndSavePDF
+        self.openPDF = openPDF
+    }
 }
 
 extension PDFClient: DependencyKey {
-    static var liveValue: PDFClient {
+    public static var liveValue: PDFClient {
         PDFClient(
             printJobDescription: { job in
                 await MainActor.run {
@@ -100,8 +110,16 @@ private func buildTextView(for job: JobApplication) -> NSTextView {
     return textView
 }
 
+extension PDFClient: TestDependencyKey {
+    public static let testValue = PDFClient(
+        printJobDescription: unimplemented("\(Self.self).printJobDescription"),
+        generateAndSavePDF: unimplemented("\(Self.self).generateAndSavePDF"),
+        openPDF: unimplemented("\(Self.self).openPDF")
+    )
+}
+
 extension DependencyValues {
-    var pdfClient: PDFClient {
+    public var pdfClient: PDFClient {
         get { self[PDFClient.self] }
         set { self[PDFClient.self] = newValue }
     }

--- a/Sources/JobApplicationWizardCore/Dependencies/PersistenceClient.swift
+++ b/Sources/JobApplicationWizardCore/Dependencies/PersistenceClient.swift
@@ -5,15 +5,35 @@ import UniformTypeIdentifiers
 
 // MARK: - PersistenceClient
 
-struct PersistenceClient {
-    var loadJobs: @Sendable () async throws -> [JobApplication]
-    var saveJobs: @Sendable ([JobApplication]) async throws -> Void
-    var loadSettings: @Sendable () async throws -> AppSettings
-    var saveSettings: @Sendable (AppSettings) async throws -> Void
-    var exportCSV: @Sendable ([JobApplication]) -> String
-    var showCSVSavePanel: @Sendable (String) async -> Void
-    var showCSVOpenPanel: @Sendable () async -> String?   // returns CSV string if user picked a file
-    var importCSV: @Sendable (String) -> [JobApplication]
+public struct PersistenceClient {
+    public var loadJobs: @Sendable () async throws -> [JobApplication]
+    public var saveJobs: @Sendable ([JobApplication]) async throws -> Void
+    public var loadSettings: @Sendable () async throws -> AppSettings
+    public var saveSettings: @Sendable (AppSettings) async throws -> Void
+    public var exportCSV: @Sendable ([JobApplication]) -> String
+    public var showCSVSavePanel: @Sendable (String) async -> Void
+    public var showCSVOpenPanel: @Sendable () async -> String?   // returns CSV string if user picked a file
+    public var importCSV: @Sendable (String) -> [JobApplication]
+
+    public init(
+        loadJobs: @escaping @Sendable () async throws -> [JobApplication],
+        saveJobs: @escaping @Sendable ([JobApplication]) async throws -> Void,
+        loadSettings: @escaping @Sendable () async throws -> AppSettings,
+        saveSettings: @escaping @Sendable (AppSettings) async throws -> Void,
+        exportCSV: @escaping @Sendable ([JobApplication]) -> String,
+        showCSVSavePanel: @escaping @Sendable (String) async -> Void,
+        showCSVOpenPanel: @escaping @Sendable () async -> String?,
+        importCSV: @escaping @Sendable (String) -> [JobApplication]
+    ) {
+        self.loadJobs = loadJobs
+        self.saveJobs = saveJobs
+        self.loadSettings = loadSettings
+        self.saveSettings = saveSettings
+        self.exportCSV = exportCSV
+        self.showCSVSavePanel = showCSVSavePanel
+        self.showCSVOpenPanel = showCSVOpenPanel
+        self.importCSV = importCSV
+    }
 }
 
 // MARK: - CSV columns (complete dump)
@@ -170,7 +190,7 @@ private func rowToJob(_ row: [String], headers: [String]) -> JobApplication? {
 // MARK: - Live value
 
 extension PersistenceClient: DependencyKey {
-    static var liveValue: PersistenceClient {
+    public static var liveValue: PersistenceClient {
         let appSupport: URL = {
             let dir = FileManager.default
                 .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
@@ -248,8 +268,21 @@ extension PersistenceClient: DependencyKey {
     }
 }
 
+extension PersistenceClient: TestDependencyKey {
+    public static let testValue = PersistenceClient(
+        loadJobs: unimplemented("\(Self.self).loadJobs"),
+        saveJobs: unimplemented("\(Self.self).saveJobs"),
+        loadSettings: unimplemented("\(Self.self).loadSettings"),
+        saveSettings: unimplemented("\(Self.self).saveSettings"),
+        exportCSV: unimplemented("\(Self.self).exportCSV"),
+        showCSVSavePanel: unimplemented("\(Self.self).showCSVSavePanel"),
+        showCSVOpenPanel: unimplemented("\(Self.self).showCSVOpenPanel"),
+        importCSV: unimplemented("\(Self.self).importCSV")
+    )
+}
+
 extension DependencyValues {
-    var persistenceClient: PersistenceClient {
+    public var persistenceClient: PersistenceClient {
         get { self[PersistenceClient.self] }
         set { self[PersistenceClient.self] = newValue }
     }

--- a/Sources/JobApplicationWizardCore/Features/AddJob/AddJobFeature.swift
+++ b/Sources/JobApplicationWizardCore/Features/AddJob/AddJobFeature.swift
@@ -2,22 +2,26 @@ import ComposableArchitecture
 import Foundation
 
 @Reducer
-struct AddJobFeature {
+public struct AddJobFeature {
+    public init() {}
+
     @ObservableState
-    struct State: Equatable {
-        var company = ""
-        var title = ""
-        var url = ""
-        var location = ""
-        var salary = ""
-        var status: JobStatus = .wishlist
-        var excitement: Int = 3
-        var jobDescription = ""
-        var selectedLabelNames: Set<String> = []
+    public struct State: Equatable {
+        public var company = ""
+        public var title = ""
+        public var url = ""
+        public var location = ""
+        public var salary = ""
+        public var status: JobStatus = .wishlist
+        public var excitement: Int = 3
+        public var jobDescription = ""
+        public var selectedLabelNames: Set<String> = []
 
-        var canSave: Bool { !company.isEmpty || !title.isEmpty }
+        public var canSave: Bool { !company.isEmpty || !title.isEmpty }
 
-        func buildJob() -> JobApplication {
+        public init() {}
+
+        public func buildJob() -> JobApplication {
             var job = JobApplication()
             job.company = company
             job.title = title
@@ -33,7 +37,7 @@ struct AddJobFeature {
         }
     }
 
-    enum Action: BindableAction {
+    public enum Action: BindableAction {
         case binding(BindingAction<State>)
         case toggleLabel(String)
         case setExcitement(Int)
@@ -41,13 +45,14 @@ struct AddJobFeature {
         case cancelTapped
         case delegate(Delegate)
 
-        enum Delegate: Equatable {
+        @CasePathable
+        public enum Delegate: Equatable {
             case save(JobApplication)
             case cancel
         }
     }
 
-    var body: some ReducerOf<Self> {
+    public var body: some ReducerOf<Self> {
         BindingReducer()
         Reduce { state, action in
             switch action {

--- a/Sources/JobApplicationWizardCore/Features/App/AppFeature.swift
+++ b/Sources/JobApplicationWizardCore/Features/App/AppFeature.swift
@@ -1,11 +1,11 @@
 import ComposableArchitecture
 import Foundation
 
-enum ViewMode: String, Codable, CaseIterable, Equatable {
+public enum ViewMode: String, Codable, CaseIterable, Equatable {
     case kanban = "Kanban"
     case list = "List"
 
-    var icon: String {
+    public var icon: String {
         switch self {
         case .kanban: return "square.grid.3x2"
         case .list:   return "list.bullet"
@@ -14,22 +14,22 @@ enum ViewMode: String, Codable, CaseIterable, Equatable {
 }
 
 @Reducer
-struct AppFeature {
+public struct AppFeature {
     @ObservableState
-    struct State: Equatable {
-        var jobs: IdentifiedArrayOf<JobApplication> = []
-        var selectedJobID: UUID? = nil
-        var searchQuery: String = ""
-        var filterStatus: JobStatus? = nil
-        var viewMode: ViewMode = .kanban
-        var showOnboarding: Bool = false
-        var showProfile: Bool = false
-        var settings: AppSettings = AppSettings()
-        var claudeAPIKey: String = ""   // runtime mirror of Keychain value; never persisted to disk
-        var addJob: AddJobFeature.State = AddJobFeature.State()
-        var jobDetail: JobDetailFeature.State? = nil
+    public struct State: Equatable {
+        public var jobs: IdentifiedArrayOf<JobApplication> = []
+        public var selectedJobID: UUID? = nil
+        public var searchQuery: String = ""
+        public var filterStatus: JobStatus? = nil
+        public var viewMode: ViewMode = .kanban
+        public var showOnboarding: Bool = false
+        public var showProfile: Bool = false
+        public var settings: AppSettings = AppSettings()
+        public var claudeAPIKey: String = ""   // runtime mirror of Keychain value; never persisted to disk
+        public var addJob: AddJobFeature.State = AddJobFeature.State()
+        public var jobDetail: JobDetailFeature.State? = nil
 
-        var filteredJobs: [JobApplication] {
+        public var filteredJobs: [JobApplication] {
             jobs.filter { job in
                 let matchesSearch = searchQuery.isEmpty ||
                     job.company.localizedCaseInsensitiveContains(searchQuery) ||
@@ -40,15 +40,17 @@ struct AppFeature {
             }
         }
 
-        var stats: (total: Int, active: Int, offers: Int, interviews: Int) {
+        public var stats: (total: Int, active: Int, offers: Int, interviews: Int) {
             let active = jobs.filter { ![.rejected, .withdrawn, .offer].contains($0.status) }.count
             let offers = jobs.filter { $0.status == .offer }.count
             let interviews = jobs.filter { $0.status == .interview }.count
             return (jobs.count, active, offers, interviews)
         }
+
+        public init() {}
     }
 
-    enum Action {
+    public enum Action {
         case onAppear
         case jobsLoaded([JobApplication])
         case settingsLoaded(AppSettings)
@@ -77,7 +79,9 @@ struct AppFeature {
     @Dependency(\.persistenceClient) var persistence
     @Dependency(\.keychainClient) var keychain
 
-    var body: some ReducerOf<Self> {
+    public init() {}
+
+    public var body: some ReducerOf<Self> {
         Scope(state: \.addJob, action: \.addJob) { AddJobFeature() }
         Reduce { state, action in
             switch action {

--- a/Sources/JobApplicationWizardCore/Features/JobDetail/JobDetailFeature.swift
+++ b/Sources/JobApplicationWizardCore/Features/JobDetail/JobDetailFeature.swift
@@ -3,45 +3,45 @@ import Foundation
 import AppKit
 
 @Reducer
-struct JobDetailFeature {
+public struct JobDetailFeature {
     @ObservableState
-    struct State: Equatable {
+    public struct State: Equatable {
         // Source of truth
-        var job: JobApplication
+        public var job: JobApplication
 
         // Flat editable fields (synced to/from job on BindingReducer changes)
-        var company: String
-        var title: String
-        var location: String
-        var salary: String
-        var url: String
-        var noteCards: [Note]
-        var jobDescription: String
-        var resumeUsed: String
-        var labels: [JobLabel]
-        var contacts: [Contact]
-        var interviews: [InterviewRound]
+        public var company: String
+        public var title: String
+        public var location: String
+        public var salary: String
+        public var url: String
+        public var noteCards: [Note]
+        public var jobDescription: String
+        public var resumeUsed: String
+        public var labels: [JobLabel]
+        public var contacts: [Contact]
+        public var interviews: [InterviewRound]
 
         // UI state
-        var selectedTab: Tab = .overview
-        var showDeleteConfirm: Bool = false
+        public var selectedTab: Tab = .overview
+        public var showDeleteConfirm: Bool = false
 
         // PDF state
-        var isGeneratingPDF: Bool = false
-        var pdfError: String? = nil
-        var showCopied: Bool = false
+        public var isGeneratingPDF: Bool = false
+        public var pdfError: String? = nil
+        public var showCopied: Bool = false
 
         // AI state
-        var aiSelectedAction: AIAction = .chat
-        var aiInput: String = ""
-        var chatMessages: [ChatMessage] = []
-        var aiIsLoading: Bool = false
-        var aiError: String? = nil
-        var apiKey: String
-        var userProfile: UserProfile
-        var aiTokenUsage: AITokenUsage = .zero
+        public var aiSelectedAction: AIAction = .chat
+        public var aiInput: String = ""
+        public var chatMessages: [ChatMessage] = []
+        public var aiIsLoading: Bool = false
+        public var aiError: String? = nil
+        public var apiKey: String
+        public var userProfile: UserProfile
+        public var aiTokenUsage: AITokenUsage = .zero
 
-        enum Tab: String, CaseIterable, Equatable {
+        public enum Tab: String, CaseIterable, Equatable {
             case overview = "Overview"
             case description = "Description"
             case notes = "Notes"
@@ -50,7 +50,7 @@ struct JobDetailFeature {
             case ai = "AI"
         }
 
-        init(job: JobApplication, apiKey: String = "", userProfile: UserProfile = UserProfile()) {
+        public init(job: JobApplication, apiKey: String = "", userProfile: UserProfile = UserProfile()) {
             self.job = job
             self.company = job.company
             self.title = job.title
@@ -68,7 +68,7 @@ struct JobDetailFeature {
         }
 
         // Build updated job from current flat fields
-        mutating func syncJobFromFields() {
+        public mutating func syncJobFromFields() {
             job.company = company
             job.title = title
             job.location = location
@@ -83,7 +83,7 @@ struct JobDetailFeature {
         }
     }
 
-    enum Action: BindableAction {
+    public enum Action: BindableAction {
         case binding(BindingAction<State>)
         case selectTab(State.Tab)
         case setExcitement(Int)
@@ -115,7 +115,8 @@ struct JobDetailFeature {
         // Delegate
         case delegate(Delegate)
 
-        enum Delegate: Equatable {
+        @CasePathable
+        public enum Delegate: Equatable {
             case jobUpdated(JobApplication)
             case jobDeleted(UUID)
         }
@@ -124,9 +125,11 @@ struct JobDetailFeature {
     @Dependency(\.pdfClient) var pdfClient
     @Dependency(\.claudeClient) var claudeClient
 
+    public init() {}
+
     private enum CancelID { case aiRequest }
 
-    var body: some ReducerOf<Self> {
+    public var body: some ReducerOf<Self> {
         BindingReducer()
         Reduce { state, action in
             switch action {

--- a/Sources/JobApplicationWizardCore/JobDetailView.swift
+++ b/Sources/JobApplicationWizardCore/JobDetailView.swift
@@ -3,10 +3,14 @@ import ComposableArchitecture
 
 // MARK: - Job Detail Panel
 
-struct JobDetailView: View {
+public struct JobDetailView: View {
     @Bindable var store: StoreOf<JobDetailFeature>
 
-    var body: some View {
+    public init(store: StoreOf<JobDetailFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
         VStack(spacing: 0) {
             header
             Divider()

--- a/Sources/JobApplicationWizardCore/KanbanView.swift
+++ b/Sources/JobApplicationWizardCore/KanbanView.swift
@@ -3,8 +3,12 @@ import ComposableArchitecture
 
 // MARK: - Main Kanban Board
 
-struct KanbanView: View {
+public struct KanbanView: View {
     let store: StoreOf<AppFeature>
+
+    public init(store: StoreOf<AppFeature>) {
+        self.store = store
+    }
 
     func jobsInColumn(_ status: JobStatus) -> [JobApplication] {
         store.filteredJobs
@@ -12,7 +16,7 @@ struct KanbanView: View {
             .sorted { $0.dateAdded > $1.dateAdded }
     }
 
-    var body: some View {
+    public var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
             VStack(spacing: 8) {
                 let visibleStatuses = store.filterStatus.map { [$0] } ?? JobStatus.allCases

--- a/Sources/JobApplicationWizardCore/ListView.swift
+++ b/Sources/JobApplicationWizardCore/ListView.swift
@@ -1,9 +1,13 @@
 import SwiftUI
 import ComposableArchitecture
 
-struct ListView: View {
+public struct ListView: View {
     let store: StoreOf<AppFeature>
     @State private var sortOrder = SortOrder.dateDesc
+
+    public init(store: StoreOf<AppFeature>) {
+        self.store = store
+    }
 
     enum SortOrder: String, CaseIterable {
         case dateDesc = "Newest First"
@@ -29,7 +33,7 @@ struct ListView: View {
         )
     }
 
-    var body: some View {
+    public var body: some View {
         VStack(spacing: 0) {
             HStack {
                 Text("\(sortedJobs.count) jobs")

--- a/Sources/JobApplicationWizardCore/Models.swift
+++ b/Sources/JobApplicationWizardCore/Models.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 // MARK: - Job Status
 
-enum JobStatus: String, Codable, CaseIterable, Identifiable, Equatable {
+public enum JobStatus: String, Codable, CaseIterable, Identifiable, Equatable {
     case wishlist = "Wishlist"
     case applied = "Applied"
     case phoneScreen = "Phone Screen"
@@ -12,9 +12,9 @@ enum JobStatus: String, Codable, CaseIterable, Identifiable, Equatable {
     case rejected = "Rejected"
     case withdrawn = "Withdrawn"
 
-    var id: String { rawValue }
+    public var id: String { rawValue }
 
-    var color: Color {
+    public var color: Color {
         switch self {
         case .wishlist:    return .purple
         case .applied:     return .blue
@@ -26,7 +26,7 @@ enum JobStatus: String, Codable, CaseIterable, Identifiable, Equatable {
         }
     }
 
-    var icon: String {
+    public var icon: String {
         switch self {
         case .wishlist:    return "star.fill"
         case .applied:     return "paperplane.fill"
@@ -41,12 +41,12 @@ enum JobStatus: String, Codable, CaseIterable, Identifiable, Equatable {
 
 // MARK: - Label
 
-struct JobLabel: Codable, Identifiable, Hashable, Equatable {
-    var id: UUID = UUID()
-    var name: String
-    var colorHex: String
+public struct JobLabel: Codable, Identifiable, Hashable, Equatable {
+    public var id: UUID = UUID()
+    public var name: String
+    public var colorHex: String
 
-    static let presets: [JobLabel] = [
+    public static let presets: [JobLabel] = [
         JobLabel(name: "Remote", colorHex: "#34C759"),
         JobLabel(name: "Hybrid", colorHex: "#FF9500"),
         JobLabel(name: "On-Site", colorHex: "#FF3B30"),
@@ -59,80 +59,116 @@ struct JobLabel: Codable, Identifiable, Hashable, Equatable {
         JobLabel(name: "Contract", colorHex: "#8E8E93"),
     ]
 
-    var color: Color {
+    public var color: Color {
         Color(hex: colorHex) ?? .blue
+    }
+
+    public init(id: UUID = UUID(), name: String, colorHex: String) {
+        self.id = id
+        self.name = name
+        self.colorHex = colorHex
     }
 }
 
 // MARK: - Note
 
-struct Note: Codable, Identifiable, Equatable {
-    var id: UUID = UUID()
-    var title: String = ""
-    var subtitle: String = ""
-    var body: String = ""
-    var tags: [String] = []
-    var createdAt: Date = Date()
-    var updatedAt: Date = Date()
+public struct Note: Codable, Identifiable, Equatable {
+    public var id: UUID = UUID()
+    public var title: String = ""
+    public var subtitle: String = ""
+    public var body: String = ""
+    public var tags: [String] = []
+    public var createdAt: Date = Date()
+    public var updatedAt: Date = Date()
+
+    public init(id: UUID = UUID(), title: String = "", subtitle: String = "", body: String = "", tags: [String] = [], createdAt: Date = Date(), updatedAt: Date = Date()) {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.body = body
+        self.tags = tags
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
 }
 
 // MARK: - Contact
 
-struct Contact: Codable, Identifiable, Equatable {
-    var id: UUID = UUID()
-    var name: String = ""
-    var title: String = ""
-    var email: String = ""
-    var linkedin: String = ""
-    var notes: String = ""
-    var connected: Bool = false
+public struct Contact: Codable, Identifiable, Equatable {
+    public var id: UUID = UUID()
+    public var name: String = ""
+    public var title: String = ""
+    public var email: String = ""
+    public var linkedin: String = ""
+    public var notes: String = ""
+    public var connected: Bool = false
+
+    public init(id: UUID = UUID(), name: String = "", title: String = "", email: String = "", linkedin: String = "", notes: String = "", connected: Bool = false) {
+        self.id = id
+        self.name = name
+        self.title = title
+        self.email = email
+        self.linkedin = linkedin
+        self.notes = notes
+        self.connected = connected
+    }
 }
 
 // MARK: - Interview Round
 
-struct InterviewRound: Codable, Identifiable, Equatable {
-    var id: UUID = UUID()
-    var round: Int
-    var type: String = ""
-    var date: Date? = nil
-    var interviewers: String = ""
-    var notes: String = ""
-    var completed: Bool = false
+public struct InterviewRound: Codable, Identifiable, Equatable {
+    public var id: UUID = UUID()
+    public var round: Int
+    public var type: String = ""
+    public var date: Date? = nil
+    public var interviewers: String = ""
+    public var notes: String = ""
+    public var completed: Bool = false
+
+    public init(id: UUID = UUID(), round: Int, type: String = "", date: Date? = nil, interviewers: String = "", notes: String = "", completed: Bool = false) {
+        self.id = id
+        self.round = round
+        self.type = type
+        self.date = date
+        self.interviewers = interviewers
+        self.notes = notes
+        self.completed = completed
+    }
 }
 
 // MARK: - Job Application
 
-struct JobApplication: Codable, Identifiable, Equatable {
-    var id: UUID = UUID()
-    var company: String = ""
-    var title: String = ""
-    var url: String = ""
-    var status: JobStatus = .wishlist
-    var dateAdded: Date = Date()
-    var dateApplied: Date? = nil
-    var salary: String = ""
-    var location: String = ""
-    var jobDescription: String = ""
-    var noteCards: [Note] = []
-    var resumeUsed: String = ""
-    var coverLetter: String = ""
-    var labels: [JobLabel] = []
-    var contacts: [Contact] = []
-    var interviews: [InterviewRound] = []
-    var isFavorite: Bool = false
-    var excitement: Int = 3
-    var hasPDF: Bool = false
-    var pdfPath: String? = nil
+public struct JobApplication: Codable, Identifiable, Equatable {
+    public var id: UUID = UUID()
+    public var company: String = ""
+    public var title: String = ""
+    public var url: String = ""
+    public var status: JobStatus = .wishlist
+    public var dateAdded: Date = Date()
+    public var dateApplied: Date? = nil
+    public var salary: String = ""
+    public var location: String = ""
+    public var jobDescription: String = ""
+    public var noteCards: [Note] = []
+    public var resumeUsed: String = ""
+    public var coverLetter: String = ""
+    public var labels: [JobLabel] = []
+    public var contacts: [Contact] = []
+    public var interviews: [InterviewRound] = []
+    public var isFavorite: Bool = false
+    public var excitement: Int = 3
+    public var hasPDF: Bool = false
+    public var pdfPath: String? = nil
 
-    var displayTitle: String {
+    public var displayTitle: String {
         title.isEmpty ? "Untitled Position" : title
     }
 
-    var displayCompany: String {
+    public var displayCompany: String {
         company.isEmpty ? "Unknown Company" : company
     }
 
-    init() {}
+    public init() {}
 
     // Custom decoder: tolerates missing keys (all default) and migrates
     // legacy `notes: String` into a noteCard.
@@ -144,7 +180,7 @@ struct JobApplication: Codable, Identifiable, Equatable {
         case legacyNotes = "notes"
     }
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         id           = try c.decodeIfPresent(UUID.self,            forKey: .id)           ?? UUID()
         company      = try c.decodeIfPresent(String.self,          forKey: .company)      ?? ""
@@ -175,7 +211,7 @@ struct JobApplication: Codable, Identifiable, Equatable {
         }
     }
 
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
         try c.encode(id,             forKey: .id)
         try c.encode(company,        forKey: .company)
@@ -202,7 +238,7 @@ struct JobApplication: Codable, Identifiable, Equatable {
 
 // MARK: - Work Preference
 
-enum WorkPreference: String, Codable, CaseIterable, Equatable {
+public enum WorkPreference: String, Codable, CaseIterable, Equatable {
     case remote   = "Remote"
     case hybrid   = "Hybrid"
     case onSite   = "On-Site"
@@ -211,35 +247,50 @@ enum WorkPreference: String, Codable, CaseIterable, Equatable {
 
 // MARK: - User Profile
 
-struct UserProfile: Codable, Equatable {
-    var name: String = ""
-    var currentTitle: String = ""
-    var location: String = ""
-    var linkedIn: String = ""
-    var website: String = ""
-    var summary: String = ""
-    var targetRoles: [String] = []
-    var skills: [String] = []
-    var preferredSalary: String = ""
-    var workPreference: WorkPreference = .flexible
-    var resume: String = ""
-    var coverLetterTemplate: String = ""
+public struct UserProfile: Codable, Equatable {
+    public var name: String = ""
+    public var currentTitle: String = ""
+    public var location: String = ""
+    public var linkedIn: String = ""
+    public var website: String = ""
+    public var summary: String = ""
+    public var targetRoles: [String] = []
+    public var skills: [String] = []
+    public var preferredSalary: String = ""
+    public var workPreference: WorkPreference = .flexible
+    public var resume: String = ""
+    public var coverLetterTemplate: String = ""
+
+    public init(name: String = "", currentTitle: String = "", location: String = "", linkedIn: String = "", website: String = "", summary: String = "", targetRoles: [String] = [], skills: [String] = [], preferredSalary: String = "", workPreference: WorkPreference = .flexible, resume: String = "", coverLetterTemplate: String = "") {
+        self.name = name
+        self.currentTitle = currentTitle
+        self.location = location
+        self.linkedIn = linkedIn
+        self.website = website
+        self.summary = summary
+        self.targetRoles = targetRoles
+        self.skills = skills
+        self.preferredSalary = preferredSalary
+        self.workPreference = workPreference
+        self.resume = resume
+        self.coverLetterTemplate = coverLetterTemplate
+    }
 }
 
 // MARK: - App Settings
 
-struct AppSettings: Codable, Equatable {
+public struct AppSettings: Codable, Equatable {
     // API key is stored in the system Keychain, not here.
-    var userProfile: UserProfile = UserProfile()
-    var defaultViewMode: ViewMode = .kanban
+    public var userProfile: UserProfile = UserProfile()
+    public var defaultViewMode: ViewMode = .kanban
 
     private enum CodingKeys: String, CodingKey {
         case userProfile, defaultViewMode
     }
 
-    init() {}
+    public init() {}
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         userProfile     = try c.decodeIfPresent(UserProfile.self, forKey: .userProfile)     ?? UserProfile()
         defaultViewMode = try c.decodeIfPresent(ViewMode.self,    forKey: .defaultViewMode) ?? .kanban
@@ -248,7 +299,7 @@ struct AppSettings: Codable, Equatable {
 
 // MARK: - AI Action
 
-enum AIAction: String, CaseIterable, Equatable {
+public enum AIAction: String, CaseIterable, Equatable {
     case chat = "Chat"
     case tailorResume = "Tailor Resume"
     case coverLetter = "Cover Letter"
@@ -258,21 +309,28 @@ enum AIAction: String, CaseIterable, Equatable {
 
 // MARK: - Chat Message
 
-struct ChatMessage: Identifiable, Equatable {
-    var id: UUID = UUID()
-    var role: Role
-    var content: String
-    var timestamp: Date = Date()
+public struct ChatMessage: Identifiable, Equatable {
+    public var id: UUID = UUID()
+    public var role: Role
+    public var content: String
+    public var timestamp: Date = Date()
 
-    enum Role: Equatable {
+    public enum Role: Equatable {
         case user, assistant
+    }
+
+    public init(id: UUID = UUID(), role: Role, content: String, timestamp: Date = Date()) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.timestamp = timestamp
     }
 }
 
 // MARK: - Color Extension
 
 extension Color {
-    init?(hex: String) {
+    public init?(hex: String) {
         var cleaned = hex.trimmingCharacters(in: .whitespacesAndNewlines)
         if cleaned.hasPrefix("#") { cleaned.removeFirst() }
         guard cleaned.count == 6, let value = UInt64(cleaned, radix: 16) else { return nil }
@@ -282,7 +340,7 @@ extension Color {
         self.init(red: r, green: g, blue: b)
     }
 
-    var hexString: String {
+    public var hexString: String {
         let components = NSColor(self).usingColorSpace(.sRGB)
         let r = Int((components?.redComponent ?? 0) * 255)
         let g = Int((components?.greenComponent ?? 0) * 255)
@@ -294,7 +352,7 @@ extension Color {
 // MARK: - String extension
 
 extension String {
-    var wordCount: Int {
+    public var wordCount: Int {
         components(separatedBy: .whitespacesAndNewlines).filter { !$0.isEmpty }.count
     }
 }
@@ -302,7 +360,7 @@ extension String {
 // MARK: - Date extension
 
 extension Date {
-    var relativeString: String {
+    public var relativeString: String {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
         return formatter.localizedString(for: self, relativeTo: Date())

--- a/Sources/JobApplicationWizardCore/ProfileView.swift
+++ b/Sources/JobApplicationWizardCore/ProfileView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct ProfileView: View {
+public struct ProfileView: View {
     let onSave: (UserProfile) -> Void
     let onDismiss: () -> Void
 
@@ -8,13 +8,13 @@ struct ProfileView: View {
     @State private var newSkill: String = ""
     @State private var newRole: String = ""
 
-    init(profile: UserProfile, onSave: @escaping (UserProfile) -> Void, onDismiss: @escaping () -> Void) {
+    public init(profile: UserProfile, onSave: @escaping (UserProfile) -> Void, onDismiss: @escaping () -> Void) {
         self._draft = State(initialValue: profile)
         self.onSave = onSave
         self.onDismiss = onDismiss
     }
 
-    var body: some View {
+    public var body: some View {
         VStack(spacing: 0) {
             // Navigation bar
             HStack {

--- a/Sources/JobApplicationWizardCore/SettingsView.swift
+++ b/Sources/JobApplicationWizardCore/SettingsView.swift
@@ -1,10 +1,14 @@
 import SwiftUI
 import ComposableArchitecture
 
-struct SettingsView: View {
+public struct SettingsView: View {
     @Bindable var store: StoreOf<AppFeature>
 
-    var body: some View {
+    public init(store: StoreOf<AppFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
         TabView {
             GeneralSettingsTab(store: store)
                 .tabItem { Label("General", systemImage: "gearshape") }

--- a/Sources/JobApplicationWizardCore/SidebarView.swift
+++ b/Sources/JobApplicationWizardCore/SidebarView.swift
@@ -1,10 +1,14 @@
 import SwiftUI
 import ComposableArchitecture
 
-struct SidebarView: View {
+public struct SidebarView: View {
     @Bindable var store: StoreOf<AppFeature>
 
-    var body: some View {
+    public init(store: StoreOf<AppFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
         VStack(spacing: 0) {
             // Stats
             VStack(spacing: 6) {

--- a/Tests/JobApplicationWizardTests/AddJobFeatureTests.swift
+++ b/Tests/JobApplicationWizardTests/AddJobFeatureTests.swift
@@ -1,0 +1,92 @@
+import ComposableArchitecture
+import XCTest
+@testable import JobApplicationWizardCore
+
+@MainActor
+final class AddJobFeatureTests: XCTestCase {
+
+    // MARK: - canSave
+
+    func testCanSaveRequiresCompanyOrTitle() {
+        var state = AddJobFeature.State()
+        XCTAssertFalse(state.canSave)
+
+        state.company = "Acme"
+        XCTAssertTrue(state.canSave)
+
+        state.company = ""
+        state.title = "Engineer"
+        XCTAssertTrue(state.canSave)
+    }
+
+    // MARK: - toggleLabel
+
+    func testToggleLabelAddsAndRemoves() async {
+        let store = TestStore(initialState: AddJobFeature.State()) {
+            AddJobFeature()
+        }
+
+        await store.send(.toggleLabel("Remote")) {
+            $0.selectedLabelNames = ["Remote"]
+        }
+        await store.send(.toggleLabel("Remote")) {
+            $0.selectedLabelNames = []
+        }
+    }
+
+    // MARK: - setExcitement
+
+    func testSetExcitement() async {
+        let store = TestStore(initialState: AddJobFeature.State()) {
+            AddJobFeature()
+        }
+
+        await store.send(.setExcitement(5)) {
+            $0.excitement = 5
+        }
+    }
+
+    // MARK: - saveTapped
+
+    func testSaveTappedBuildsJobAndDelegates() async {
+        var state = AddJobFeature.State()
+        state.company = "Acme"
+        state.title = "Engineer"
+        state.salary = "$100k"
+        state.selectedLabelNames = ["Remote"]
+
+        let store = TestStore(initialState: state) {
+            AddJobFeature()
+        }
+
+        await store.send(.saveTapped)
+
+        // Should receive a delegate save action with the built job
+        await store.receive(\.delegate.save)
+    }
+
+    func testSaveTappedWithAppliedStatusSetsDateApplied() async {
+        var state = AddJobFeature.State()
+        state.company = "Acme"
+        state.status = .applied
+
+        let store = TestStore(initialState: state) {
+            AddJobFeature()
+        }
+
+        await store.send(.saveTapped)
+
+        await store.receive(\.delegate.save)
+    }
+
+    // MARK: - cancelTapped
+
+    func testCancelTappedDelegatesCancel() async {
+        let store = TestStore(initialState: AddJobFeature.State()) {
+            AddJobFeature()
+        }
+
+        await store.send(.cancelTapped)
+        await store.receive(\.delegate.cancel)
+    }
+}

--- a/Tests/JobApplicationWizardTests/AppFeatureTests.swift
+++ b/Tests/JobApplicationWizardTests/AppFeatureTests.swift
@@ -1,0 +1,393 @@
+import ComposableArchitecture
+import XCTest
+@testable import JobApplicationWizardCore
+
+@MainActor
+final class AppFeatureTests: XCTestCase {
+
+    // MARK: - onAppear
+
+    func testOnAppearLoadsJobsSettingsAndAPIKey() async {
+        let jobs = [JobApplication.mock()]
+        let settings: AppSettings = {
+            var s = AppSettings()
+            s.userProfile.name = "Test"
+            return s
+        }()
+
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.persistenceClient.loadJobs = { jobs }
+            $0.persistenceClient.loadSettings = { settings }
+            $0.keychainClient.loadAPIKey = { "sk-test-key" }
+            $0.keychainClient.saveAPIKey = { _ in }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.jobsLoaded) {
+            $0.jobs = IdentifiedArray(uniqueElements: jobs)
+        }
+        await store.receive(\.settingsLoaded) {
+            $0.settings = settings
+            $0.viewMode = settings.defaultViewMode
+        }
+        await store.receive(\.saveSettingsKey) {
+            $0.claudeAPIKey = "sk-test-key"
+        }
+    }
+
+    func testEmptyJobsTriggersOnboarding() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.persistenceClient.loadJobs = { [] }
+            $0.persistenceClient.loadSettings = { AppSettings() }
+            $0.keychainClient.loadAPIKey = { "" }
+            $0.keychainClient.saveAPIKey = { _ in }
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.jobsLoaded) {
+            $0.jobs = []
+            $0.showOnboarding = true
+        }
+        await store.receive(\.settingsLoaded)
+        await store.receive(\.saveSettingsKey)
+    }
+
+    // MARK: - Search & Filter
+
+    func testSearchQueryChanged() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        }
+
+        await store.send(.searchQueryChanged("test")) {
+            $0.searchQuery = "test"
+        }
+    }
+
+    func testFilterStatusChanged() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        }
+
+        await store.send(.filterStatusChanged(.applied)) {
+            $0.filterStatus = .applied
+        }
+        await store.send(.filterStatusChanged(nil)) {
+            $0.filterStatus = nil
+        }
+    }
+
+    func testFilteredJobsRespectsSearchAndStatus() {
+        var state = AppFeature.State()
+        state.jobs = IdentifiedArray(uniqueElements: [
+            .mock(id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!, company: "Alpha", status: .applied),
+            .mock(id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!, company: "Beta", status: .wishlist),
+            .mock(id: UUID(uuidString: "00000000-0000-0000-0000-000000000003")!, company: "Gamma", status: .applied),
+        ])
+
+        // Filter by status
+        state.filterStatus = .applied
+        XCTAssertEqual(state.filteredJobs.count, 2)
+
+        // Filter by search
+        state.filterStatus = nil
+        state.searchQuery = "Beta"
+        XCTAssertEqual(state.filteredJobs.count, 1)
+        XCTAssertEqual(state.filteredJobs.first?.company, "Beta")
+    }
+
+    // MARK: - selectJob
+
+    func testSelectJobCreatesJobDetailState() async {
+        let job = JobApplication.mock()
+        var state = AppFeature.State()
+        state.jobs = IdentifiedArray(uniqueElements: [job])
+
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        }
+
+        await store.send(.selectJob(job.id)) {
+            $0.selectedJobID = job.id
+            $0.jobDetail = JobDetailFeature.State(job: job)
+        }
+    }
+
+    func testSelectNilClearsJobDetail() async {
+        let job = JobApplication.mock()
+        var state = AppFeature.State()
+        state.jobs = IdentifiedArray(uniqueElements: [job])
+        state.selectedJobID = job.id
+        state.jobDetail = JobDetailFeature.State(job: job)
+
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        }
+
+        await store.send(.selectJob(nil)) {
+            $0.selectedJobID = nil
+            $0.jobDetail = nil
+        }
+    }
+
+    // MARK: - moveJob
+
+    func testMoveJobUpdatesStatusAndSaves() async {
+        let job = JobApplication.mock()
+        var state = AppFeature.State()
+        state.jobs = IdentifiedArray(uniqueElements: [job])
+
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.persistenceClient.saveJobs = { _ in }
+        }
+
+        store.exhaustivity = .off
+        await store.send(.moveJob(job.id, .applied))
+
+        // Verify status and dateApplied were set
+        XCTAssertEqual(store.state.jobs[id: job.id]?.status, .applied)
+        XCTAssertNotNil(store.state.jobs[id: job.id]?.dateApplied)
+    }
+
+    func testMoveJobSyncsToJobDetail() async {
+        let job = JobApplication.mock()
+        var state = AppFeature.State()
+        state.jobs = IdentifiedArray(uniqueElements: [job])
+        state.selectedJobID = job.id
+        state.jobDetail = JobDetailFeature.State(job: job)
+
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.persistenceClient.saveJobs = { _ in }
+        }
+
+        await store.send(.moveJob(job.id, .interview)) {
+            var updatedJob = job
+            updatedJob.status = .interview
+            $0.jobs[id: job.id] = updatedJob
+            $0.jobDetail?.job = updatedJob
+        }
+    }
+
+    // MARK: - deleteJob
+
+    func testDeleteJobRemovesAndClearsSelection() async {
+        let job = JobApplication.mock()
+        var state = AppFeature.State()
+        state.jobs = IdentifiedArray(uniqueElements: [job])
+        state.selectedJobID = job.id
+        state.jobDetail = JobDetailFeature.State(job: job)
+
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.persistenceClient.saveJobs = { _ in }
+        }
+
+        await store.send(.deleteJob(job.id)) {
+            $0.jobs = []
+            $0.selectedJobID = nil
+            $0.jobDetail = nil
+        }
+    }
+
+    // MARK: - toggleFavorite
+
+    func testToggleFavorite() async {
+        let job = JobApplication.mock()
+        var state = AppFeature.State()
+        state.jobs = IdentifiedArray(uniqueElements: [job])
+
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.persistenceClient.saveJobs = { _ in }
+        }
+
+        await store.send(.toggleFavorite(job.id)) {
+            $0.jobs[id: job.id]?.isFavorite = true
+        }
+    }
+
+    // MARK: - Child Delegation: AddJob
+
+    func testAddJobSaveDelegateSavesAndSelects() async {
+        let newJob = JobApplication.mock()
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.persistenceClient.saveJobs = { _ in }
+        }
+
+        await store.send(.addJob(.delegate(.save(newJob)))) {
+            $0.jobs.append(newJob)
+            $0.selectedJobID = newJob.id
+            $0.jobDetail = JobDetailFeature.State(job: newJob)
+            $0.addJob = AddJobFeature.State()
+        }
+    }
+
+    func testAddJobCancelDelegateResetsState() async {
+        var state = AppFeature.State()
+        state.addJob.company = "Partial"
+
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        }
+
+        await store.send(.addJob(.delegate(.cancel))) {
+            $0.addJob = AddJobFeature.State()
+        }
+    }
+
+    // MARK: - Child Delegation: JobDetail
+
+    func testJobDetailUpdatedDelegateSyncsBack() async {
+        var job = JobApplication.mock()
+        var state = AppFeature.State()
+        state.jobs = IdentifiedArray(uniqueElements: [job])
+        state.selectedJobID = job.id
+        state.jobDetail = JobDetailFeature.State(job: job)
+
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.persistenceClient.saveJobs = { _ in }
+        }
+
+        job.company = "Updated Corp"
+        await store.send(.jobDetail(.delegate(.jobUpdated(job)))) {
+            $0.jobs[id: job.id] = job
+        }
+    }
+
+    func testJobDetailDeletedDelegateRemovesJob() async {
+        let job = JobApplication.mock()
+        var state = AppFeature.State()
+        state.jobs = IdentifiedArray(uniqueElements: [job])
+        state.selectedJobID = job.id
+        state.jobDetail = JobDetailFeature.State(job: job)
+
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.persistenceClient.saveJobs = { _ in }
+        }
+
+        await store.send(.jobDetail(.delegate(.jobDeleted(job.id)))) {
+            $0.jobs = []
+            $0.selectedJobID = nil
+            $0.jobDetail = nil
+        }
+    }
+
+    // MARK: - importCSVResult
+
+    func testImportCSVResultMergesAndSkipsExisting() async {
+        let existing = JobApplication.mock(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+            company: "Existing"
+        )
+        let newJob = JobApplication.mock(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+            company: "Imported"
+        )
+        let duplicate = JobApplication.mock(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+            company: "Should Be Skipped"
+        )
+
+        var state = AppFeature.State()
+        state.jobs = IdentifiedArray(uniqueElements: [existing])
+        state.filterStatus = .applied
+
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.persistenceClient.saveJobs = { _ in }
+        }
+
+        await store.send(.importCSVResult([duplicate, newJob])) {
+            $0.jobs.append(newJob)
+            $0.filterStatus = nil  // cleared to show imported jobs
+        }
+
+        // Verify the existing job was NOT overwritten
+        XCTAssertEqual(store.state.jobs[id: existing.id]?.company, "Existing")
+    }
+
+    // MARK: - saveSettingsKey
+
+    func testSaveSettingsKeySyncsToJobDetail() async {
+        let job = JobApplication.mock()
+        var state = AppFeature.State()
+        state.jobs = IdentifiedArray(uniqueElements: [job])
+        state.selectedJobID = job.id
+        state.jobDetail = JobDetailFeature.State(job: job)
+
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.keychainClient.saveAPIKey = { _ in }
+        }
+
+        await store.send(.saveSettingsKey("new-key")) {
+            $0.claudeAPIKey = "new-key"
+            $0.jobDetail?.apiKey = "new-key"
+        }
+    }
+
+    // MARK: - saveProfile
+
+    func testSaveProfileUpdatesSettingsAndSyncsToJobDetail() async {
+        let job = JobApplication.mock()
+        var state = AppFeature.State()
+        state.jobs = IdentifiedArray(uniqueElements: [job])
+        state.selectedJobID = job.id
+        state.jobDetail = JobDetailFeature.State(job: job)
+
+        var profile = UserProfile()
+        profile.name = "Updated Name"
+
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.persistenceClient.saveSettings = { _ in }
+        }
+
+        await store.send(.saveProfile(profile)) {
+            $0.settings.userProfile = profile
+            $0.jobDetail?.userProfile = profile
+        }
+    }
+
+    // MARK: - resetAllData
+
+    func testResetAllDataClearsEverything() async {
+        let job = JobApplication.mock()
+        var state = AppFeature.State()
+        state.jobs = IdentifiedArray(uniqueElements: [job])
+        state.selectedJobID = job.id
+        state.jobDetail = JobDetailFeature.State(job: job)
+
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.persistenceClient.saveJobs = { _ in }
+        }
+
+        await store.send(.resetAllData) {
+            $0.jobs = []
+            $0.selectedJobID = nil
+            $0.jobDetail = nil
+            $0.showOnboarding = true
+        }
+    }
+}

--- a/Tests/JobApplicationWizardTests/CSVTests.swift
+++ b/Tests/JobApplicationWizardTests/CSVTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import JobApplicationWizardCore
+
+final class CSVTests: XCTestCase {
+
+    // Use the live persistence client's exportCSV/importCSV closures directly —
+    // they are pure functions (no disk I/O).
+    private let export: ([JobApplication]) -> String = PersistenceClient.liveValue.exportCSV
+    private let importCSV: (String) -> [JobApplication] = PersistenceClient.liveValue.importCSV
+
+    // MARK: - Round-Trips
+
+    func testSingleJobRoundTrip() {
+        let job = JobApplication.mock()
+        let csv = export([job])
+        let imported = importCSV(csv)
+        XCTAssertEqual(imported.count, 1)
+        XCTAssertEqual(imported.first?.id, job.id)
+        XCTAssertEqual(imported.first?.company, "Acme Corp")
+        XCTAssertEqual(imported.first?.title, "Software Engineer")
+        XCTAssertEqual(imported.first?.status, .wishlist)
+        XCTAssertEqual(imported.first?.salary, "$120k")
+    }
+
+    func testMultipleJobsRoundTrip() {
+        let job1 = JobApplication.mock(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+            company: "Alpha",
+            dateAdded: Date(timeIntervalSinceReferenceDate: 100)
+        )
+        let job2 = JobApplication.mock(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+            company: "Beta",
+            dateAdded: Date(timeIntervalSinceReferenceDate: 200)
+        )
+        let csv = export([job1, job2])
+        let imported = importCSV(csv)
+        XCTAssertEqual(imported.count, 2)
+        let companies = Set(imported.map(\.company))
+        XCTAssertTrue(companies.contains("Alpha"))
+        XCTAssertTrue(companies.contains("Beta"))
+    }
+
+    func testRoundTripWithLabels() {
+        let job = JobApplication.mock(
+            labels: [JobLabel(name: "Remote", colorHex: "#34C759")]
+        )
+        let csv = export([job])
+        let imported = importCSV(csv)
+        XCTAssertEqual(imported.first?.labels.count, 1)
+        XCTAssertEqual(imported.first?.labels.first?.name, "Remote")
+    }
+
+    func testRoundTripWithContacts() {
+        let contact = Contact(name: "Alice", title: "Recruiter", email: "a@b.com")
+        let job = JobApplication.mock(contacts: [contact])
+        let csv = export([job])
+        let imported = importCSV(csv)
+        XCTAssertEqual(imported.first?.contacts.count, 1)
+        XCTAssertEqual(imported.first?.contacts.first?.name, "Alice")
+    }
+
+    func testRoundTripWithInterviews() {
+        let interview = InterviewRound(round: 1, type: "Phone", interviewers: "Bob")
+        let job = JobApplication.mock(interviews: [interview])
+        let csv = export([job])
+        let imported = importCSV(csv)
+        XCTAssertEqual(imported.first?.interviews.count, 1)
+        XCTAssertEqual(imported.first?.interviews.first?.type, "Phone")
+    }
+
+    func testRoundTripWithNoteCards() {
+        let note = Note(title: "First", body: "Some content")
+        let job = JobApplication.mock(noteCards: [note])
+        let csv = export([job])
+        let imported = importCSV(csv)
+        XCTAssertEqual(imported.first?.noteCards.count, 1)
+        XCTAssertEqual(imported.first?.noteCards.first?.title, "First")
+    }
+
+    // MARK: - Edge Cases
+
+    func testEmbeddedCommas() {
+        let job = JobApplication.mock(company: "Acme, Inc.", salary: "$100,000")
+        let csv = export([job])
+        let imported = importCSV(csv)
+        XCTAssertEqual(imported.first?.company, "Acme, Inc.")
+        XCTAssertEqual(imported.first?.salary, "$100,000")
+    }
+
+    func testEmbeddedNewlines() {
+        let job = JobApplication.mock(jobDescription: "Line one\nLine two\nLine three")
+        let csv = export([job])
+        let imported = importCSV(csv)
+        XCTAssertEqual(imported.first?.jobDescription, "Line one\nLine two\nLine three")
+    }
+
+    func testEscapedQuotes() {
+        let job = JobApplication.mock(company: "Say \"Hello\" Corp")
+        let csv = export([job])
+        let imported = importCSV(csv)
+        XCTAssertEqual(imported.first?.company, "Say \"Hello\" Corp")
+    }
+
+    // MARK: - Empty / Header-Only
+
+    func testEmptyInputReturnsEmptyArray() {
+        XCTAssertEqual(importCSV("").count, 0)
+    }
+
+    func testHeaderOnlyReturnsEmptyArray() {
+        let csv = "ID,Company,Title,URL,Status,DateAdded,DateApplied,Salary,Location,Excitement,IsFavorite,Labels,JobDescription,NoteCards,ResumeUsed,CoverLetter,Contacts,Interviews,HasPDF,PDFPath"
+        XCTAssertEqual(importCSV(csv).count, 0)
+    }
+
+    // MARK: - Invalid Rows
+
+    func testRowsWithBothCompanyAndTitleEmptySkipped() {
+        // Build a CSV with a valid header and one row that has empty company and title
+        let header = "ID,Company,Title,URL,Status"
+        let row = "\"00000000-0000-0000-0000-000000000099\",\"\",\"\",\"\",\"Wishlist\""
+        let csv = header + "\n" + row
+        let imported = importCSV(csv)
+        XCTAssertEqual(imported.count, 0)
+    }
+
+    // MARK: - Sort Order
+
+    func testExportSortsByDateAddedDescending() {
+        let older = JobApplication.mock(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+            company: "Older",
+            dateAdded: Date(timeIntervalSinceReferenceDate: 100)
+        )
+        let newer = JobApplication.mock(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+            company: "Newer",
+            dateAdded: Date(timeIntervalSinceReferenceDate: 200)
+        )
+        let csv = export([older, newer])
+        let lines = csv.components(separatedBy: "\n")
+        // First data line (index 1) should be the newer job
+        XCTAssertTrue(lines[1].contains("Newer"))
+        XCTAssertTrue(lines[2].contains("Older"))
+    }
+}

--- a/Tests/JobApplicationWizardTests/JobDetailFeatureTests.swift
+++ b/Tests/JobApplicationWizardTests/JobDetailFeatureTests.swift
@@ -1,0 +1,449 @@
+import ComposableArchitecture
+import XCTest
+@testable import JobApplicationWizardCore
+
+@MainActor
+final class JobDetailFeatureTests: XCTestCase {
+
+    // MARK: - State Init
+
+    func testStateInitMapsAllFieldsFromJob() {
+        let job = JobApplication.mock(
+            company: "Acme",
+            title: "Engineer",
+            url: "https://acme.com",
+            salary: "$100k",
+            location: "Remote",
+            jobDescription: "Do things",
+            noteCards: [Note(title: "N1")],
+            labels: [JobLabel(name: "Remote", colorHex: "#34C759")],
+            contacts: [Contact(name: "Alice")],
+            interviews: [InterviewRound(round: 1)]
+        )
+        let state = JobDetailFeature.State(job: job, apiKey: "key", userProfile: UserProfile())
+        XCTAssertEqual(state.company, "Acme")
+        XCTAssertEqual(state.title, "Engineer")
+        XCTAssertEqual(state.location, "Remote")
+        XCTAssertEqual(state.salary, "$100k")
+        XCTAssertEqual(state.url, "https://acme.com")
+        XCTAssertEqual(state.jobDescription, "Do things")
+        XCTAssertEqual(state.noteCards.count, 1)
+        XCTAssertEqual(state.labels.count, 1)
+        XCTAssertEqual(state.contacts.count, 1)
+        XCTAssertEqual(state.interviews.count, 1)
+        XCTAssertEqual(state.apiKey, "key")
+    }
+
+    // MARK: - syncJobFromFields
+
+    func testSyncJobFromFieldsWritesBack() {
+        let job = JobApplication.mock()
+        var state = JobDetailFeature.State(job: job)
+        state.company = "Changed"
+        state.title = "New Title"
+        state.syncJobFromFields()
+        XCTAssertEqual(state.job.company, "Changed")
+        XCTAssertEqual(state.job.title, "New Title")
+    }
+
+    // MARK: - Tab Selection
+
+    func testSelectTab() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock())) {
+            JobDetailFeature()
+        }
+
+        await store.send(.selectTab(.notes)) {
+            $0.selectedTab = .notes
+        }
+    }
+
+    // MARK: - Excitement
+
+    func testSetExcitement() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock())) {
+            JobDetailFeature()
+        }
+
+        await store.send(.setExcitement(5)) {
+            $0.job.excitement = 5
+        }
+        await store.receive(\.delegate.jobUpdated)
+    }
+
+    // MARK: - Favorite
+
+    func testToggleFavorite() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock())) {
+            JobDetailFeature()
+        }
+
+        await store.send(.toggleFavorite) {
+            $0.job.isFavorite = true
+        }
+        await store.receive(\.delegate.jobUpdated)
+    }
+
+    // MARK: - moveJob
+
+    func testMoveJob() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock())) {
+            JobDetailFeature()
+        }
+
+        await store.send(.moveJob(.interview)) {
+            $0.job.status = .interview
+        }
+        await store.receive(\.delegate.jobUpdated)
+    }
+
+    func testMoveJobToAppliedSetsDateApplied() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock())) {
+            JobDetailFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.moveJob(.applied))
+
+        XCTAssertEqual(store.state.job.status, .applied)
+        XCTAssertNotNil(store.state.job.dateApplied)
+    }
+
+    // MARK: - markApplied
+
+    func testMarkApplied() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock())) {
+            JobDetailFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.markApplied)
+
+        XCTAssertEqual(store.state.job.status, .applied)
+        XCTAssertNotNil(store.state.job.dateApplied)
+    }
+
+    // MARK: - Delete Flow
+
+    func testDeleteTappedShowsConfirm() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock())) {
+            JobDetailFeature()
+        }
+
+        await store.send(.deleteTapped) {
+            $0.showDeleteConfirm = true
+        }
+    }
+
+    func testDeleteConfirmedDelegates() async {
+        var state = JobDetailFeature.State(job: .mock())
+        state.showDeleteConfirm = true
+
+        let store = TestStore(initialState: state) {
+            JobDetailFeature()
+        }
+
+        await store.send(.deleteConfirmed) {
+            $0.showDeleteConfirm = false
+        }
+        await store.receive(\.delegate.jobDeleted)
+    }
+
+    func testDeleteCancelled() async {
+        var state = JobDetailFeature.State(job: .mock())
+        state.showDeleteConfirm = true
+
+        let store = TestStore(initialState: state) {
+            JobDetailFeature()
+        }
+
+        await store.send(.deleteCancelled) {
+            $0.showDeleteConfirm = false
+        }
+    }
+
+    // MARK: - Notes CRUD
+
+    func testAddNote() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock())) {
+            JobDetailFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.addNote)
+
+        XCTAssertEqual(store.state.noteCards.count, 1)
+        XCTAssertEqual(store.state.job.noteCards.count, 1)
+    }
+
+    func testDeleteNote() async {
+        let note = Note(id: UUID(uuidString: "00000000-0000-0000-0000-000000000099")!, title: "Test")
+        let job = JobApplication.mock(noteCards: [note])
+
+        let store = TestStore(initialState: JobDetailFeature.State(job: job)) {
+            JobDetailFeature()
+        }
+
+        await store.send(.deleteNote(note.id)) {
+            $0.noteCards = []
+            $0.job.noteCards = []
+        }
+        await store.receive(\.delegate.jobUpdated)
+    }
+
+    // MARK: - Contact CRUD
+
+    func testAddContact() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock())) {
+            JobDetailFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.addContact)
+
+        XCTAssertEqual(store.state.contacts.count, 1)
+        XCTAssertEqual(store.state.job.contacts.count, 1)
+    }
+
+    func testDeleteContact() async {
+        let contact = Contact(name: "Alice")
+        let job = JobApplication.mock(contacts: [contact])
+
+        let store = TestStore(initialState: JobDetailFeature.State(job: job)) {
+            JobDetailFeature()
+        }
+
+        await store.send(.deleteContact(IndexSet(integer: 0))) {
+            $0.contacts = []
+            $0.job.contacts = []
+        }
+        await store.receive(\.delegate.jobUpdated)
+    }
+
+    // MARK: - Interview CRUD
+
+    func testAddInterview() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock())) {
+            JobDetailFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.addInterview)
+
+        XCTAssertEqual(store.state.interviews.count, 1)
+        XCTAssertEqual(store.state.interviews.first?.round, 1)
+        XCTAssertEqual(store.state.job.interviews.count, 1)
+    }
+
+    func testDeleteInterview() async {
+        let interview = InterviewRound(round: 1, type: "Phone")
+        let job = JobApplication.mock(interviews: [interview])
+
+        let store = TestStore(initialState: JobDetailFeature.State(job: job)) {
+            JobDetailFeature()
+        }
+
+        await store.send(.deleteInterview(IndexSet(integer: 0))) {
+            $0.interviews = []
+            $0.job.interviews = []
+        }
+        await store.receive(\.delegate.jobUpdated)
+    }
+
+    // MARK: - AI: sendMessage
+
+    func testSendMessageWithChatMode() async {
+        var state = JobDetailFeature.State(job: .mock(), apiKey: "test-key")
+        state.aiInput = "Hello"
+
+        let store = TestStore(initialState: state) {
+            JobDetailFeature()
+        } withDependencies: {
+            $0.claudeClient.chat = { _, _, _ in
+                ("AI response", AITokenUsage(inputTokens: 10, outputTokens: 20))
+            }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.sendMessage)
+        await store.receive(\.aiResponseReceived)
+
+        XCTAssertFalse(store.state.aiIsLoading)
+        XCTAssertEqual(store.state.chatMessages.count, 2)
+        XCTAssertEqual(store.state.chatMessages[0].role, .user)
+        XCTAssertEqual(store.state.chatMessages[0].content, "Hello")
+        XCTAssertEqual(store.state.chatMessages[1].role, .assistant)
+        XCTAssertEqual(store.state.chatMessages[1].content, "AI response")
+        XCTAssertEqual(store.state.aiTokenUsage, AITokenUsage(inputTokens: 10, outputTokens: 20))
+        XCTAssertEqual(store.state.aiInput, "")
+    }
+
+    func testSendMessageWithTailorResumeMode() async {
+        var state = JobDetailFeature.State(job: .mock(), apiKey: "test-key")
+        state.aiInput = "My resume"
+        state.aiSelectedAction = .tailorResume
+
+        let store = TestStore(initialState: state) {
+            JobDetailFeature()
+        } withDependencies: {
+            $0.claudeClient.chat = { _, _, _ in
+                ("Tailored", AITokenUsage(inputTokens: 5, outputTokens: 10))
+            }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.sendMessage)
+        await store.receive(\.aiResponseReceived)
+
+        XCTAssertEqual(store.state.chatMessages.count, 2)
+        XCTAssertTrue(store.state.chatMessages[0].content.contains("analyze my resume"))
+        XCTAssertEqual(store.state.chatMessages[1].content, "Tailored")
+        XCTAssertEqual(store.state.aiSelectedAction, .chat)  // resets to chat after sending
+    }
+
+    func testSendMessageAIResponseError() async {
+        var state = JobDetailFeature.State(job: .mock(), apiKey: "test-key")
+        state.aiInput = "Hello"
+
+        let store = TestStore(initialState: state) {
+            JobDetailFeature()
+        } withDependencies: {
+            $0.claudeClient.chat = { _, _, _ in
+                throw AIError.noAPIKey
+            }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.sendMessage)
+        await store.receive(\.aiResponseReceived)
+
+        XCTAssertFalse(store.state.aiIsLoading)
+        XCTAssertEqual(store.state.aiError, AIError.noAPIKey.localizedDescription)
+    }
+
+    func testSendMessageEmptyInputDoesNothing() async {
+        var state = JobDetailFeature.State(job: .mock(), apiKey: "test-key")
+        state.aiInput = "   "
+
+        let store = TestStore(initialState: state) {
+            JobDetailFeature()
+        }
+
+        await store.send(.sendMessage)
+        // No state changes, no effects
+    }
+
+    // MARK: - AI: clearChat
+
+    func testClearChat() async {
+        var state = JobDetailFeature.State(job: .mock())
+        state.chatMessages = [ChatMessage(role: .user, content: "test")]
+        state.aiInput = "something"
+        state.aiError = "some error"
+        state.aiTokenUsage = AITokenUsage(inputTokens: 100, outputTokens: 200)
+
+        let store = TestStore(initialState: state) {
+            JobDetailFeature()
+        }
+
+        await store.send(.clearChat) {
+            $0.chatMessages = []
+            $0.aiInput = ""
+            $0.aiError = nil
+            $0.aiTokenUsage = .zero
+        }
+    }
+
+    // MARK: - AI: response accumulates token usage
+
+    func testAIResponseAccumulatesTokenUsage() async {
+        var state = JobDetailFeature.State(job: .mock(), apiKey: "test-key")
+        state.aiTokenUsage = AITokenUsage(inputTokens: 100, outputTokens: 200)
+        state.aiInput = "More"
+
+        let store = TestStore(initialState: state) {
+            JobDetailFeature()
+        } withDependencies: {
+            $0.claudeClient.chat = { _, _, _ in
+                ("Response", AITokenUsage(inputTokens: 50, outputTokens: 75))
+            }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.sendMessage)
+        await store.receive(\.aiResponseReceived)
+
+        XCTAssertEqual(store.state.aiTokenUsage.inputTokens, 150)
+        XCTAssertEqual(store.state.aiTokenUsage.outputTokens, 275)
+        XCTAssertEqual(store.state.chatMessages.count, 2)
+        XCTAssertEqual(store.state.chatMessages.last?.content, "Response")
+    }
+
+    // MARK: - PDF
+
+    func testSavePDFSuccess() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock())) {
+            JobDetailFeature()
+        } withDependencies: {
+            $0.pdfClient.generateAndSavePDF = { _ in "/path/to/pdf" }
+        }
+
+        await store.send(.savePDFTapped) {
+            $0.isGeneratingPDF = true
+            $0.pdfError = nil
+        }
+
+        await store.receive(\.pdfSaved.success) {
+            $0.isGeneratingPDF = false
+            $0.job.hasPDF = true
+            $0.job.pdfPath = "/path/to/pdf"
+        }
+        await store.receive(\.delegate.jobUpdated)
+    }
+
+    func testSavePDFFailure() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock())) {
+            JobDetailFeature()
+        } withDependencies: {
+            $0.pdfClient.generateAndSavePDF = { _ in
+                throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "PDF failed"])
+            }
+        }
+
+        await store.send(.savePDFTapped) {
+            $0.isGeneratingPDF = true
+            $0.pdfError = nil
+        }
+
+        await store.receive(\.pdfSaved.failure) {
+            $0.isGeneratingPDF = false
+            $0.pdfError = "PDF failed"
+        }
+    }
+
+    func testViewPDFWithPath() async {
+        var job = JobApplication.mock()
+        job.pdfPath = "/some/path.pdf"
+        let openedPath = LockIsolated<String?>(nil)
+
+        let store = TestStore(initialState: JobDetailFeature.State(job: job)) {
+            JobDetailFeature()
+        } withDependencies: {
+            $0.pdfClient.openPDF = { path in
+                openedPath.setValue(path)
+            }
+        }
+
+        await store.send(.viewPDFTapped)
+        XCTAssertEqual(openedPath.value, "/some/path.pdf")
+    }
+
+    func testViewPDFWithoutPathDoesNothing() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock())) {
+            JobDetailFeature()
+        }
+
+        await store.send(.viewPDFTapped)
+        // No effect, no crash
+    }
+}

--- a/Tests/JobApplicationWizardTests/ModelTests.swift
+++ b/Tests/JobApplicationWizardTests/ModelTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+import SwiftUI
+@testable import JobApplicationWizardCore
+
+final class ModelTests: XCTestCase {
+
+    // MARK: - JobApplication Codable Round-Trip
+
+    func testJobApplicationCodableRoundTrip() throws {
+        let job = JobApplication.mock(
+            noteCards: [Note(title: "First", body: "Body text")],
+            labels: [JobLabel(name: "Remote", colorHex: "#34C759")],
+            contacts: [Contact(name: "Alice", title: "Recruiter")],
+            interviews: [InterviewRound(round: 1, type: "Phone")]
+        )
+        let data = try JSONEncoder().encode(job)
+        let decoded = try JSONDecoder().decode(JobApplication.self, from: data)
+        XCTAssertEqual(decoded.id, job.id)
+        XCTAssertEqual(decoded.company, job.company)
+        XCTAssertEqual(decoded.title, job.title)
+        XCTAssertEqual(decoded.status, job.status)
+        XCTAssertEqual(decoded.labels.count, 1)
+        XCTAssertEqual(decoded.contacts.count, 1)
+        XCTAssertEqual(decoded.interviews.count, 1)
+        XCTAssertEqual(decoded.noteCards.count, 1)
+        XCTAssertEqual(decoded.excitement, 3)
+    }
+
+    func testAppSettingsCodableRoundTrip() throws {
+        var settings = AppSettings()
+        settings.userProfile.name = "Test User"
+        settings.defaultViewMode = .list
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+        XCTAssertEqual(decoded.userProfile.name, "Test User")
+        XCTAssertEqual(decoded.defaultViewMode, .list)
+    }
+
+    // MARK: - Legacy Migration
+
+    func testLegacyNotesStringMigratesToNoteCards() throws {
+        let json = """
+        {"id":"00000000-0000-0000-0000-000000000001","company":"Test","notes":"Old notes text"}
+        """
+        let job = try JSONDecoder().decode(JobApplication.self, from: Data(json.utf8))
+        XCTAssertEqual(job.noteCards.count, 1)
+        XCTAssertEqual(job.noteCards.first?.title, "Notes")
+        XCTAssertEqual(job.noteCards.first?.body, "Old notes text")
+    }
+
+    func testEmptyLegacyNotesDoesNotCreateNoteCard() throws {
+        let json = """
+        {"id":"00000000-0000-0000-0000-000000000001","company":"Test","notes":""}
+        """
+        let job = try JSONDecoder().decode(JobApplication.self, from: Data(json.utf8))
+        XCTAssertEqual(job.noteCards.count, 0)
+    }
+
+    func testNoteCardsPreferredOverLegacyNotes() throws {
+        let json = """
+        {"company":"Test","noteCards":[{"id":"00000000-0000-0000-0000-000000000002","title":"Card","subtitle":"","body":"New","tags":[],"createdAt":0,"updatedAt":0}],"notes":"Old"}
+        """
+        let job = try JSONDecoder().decode(JobApplication.self, from: Data(json.utf8))
+        XCTAssertEqual(job.noteCards.count, 1)
+        XCTAssertEqual(job.noteCards.first?.body, "New")
+    }
+
+    // MARK: - AppSettings Tolerates Missing Keys
+
+    func testAppSettingsToleratesUnknownTopLevelKeys() throws {
+        // AppSettings uses explicit CodingKeys, so unknown keys at the top level are silently ignored.
+        // This verifies the profile-loss bug fix: unknown keys don't crash decoding.
+        let json = """
+        {"unknownKey":"something","defaultViewMode":"Kanban"}
+        """
+        let settings = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
+        XCTAssertEqual(settings.userProfile.name, "")
+        XCTAssertEqual(settings.defaultViewMode, .kanban)
+    }
+
+    func testAppSettingsDefaultsOnEmptyJSON() throws {
+        let json = "{}"
+        let settings = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
+        XCTAssertEqual(settings.userProfile.name, "")
+        XCTAssertEqual(settings.defaultViewMode, .kanban)
+    }
+
+    // MARK: - JobApplication Defaults on Empty JSON
+
+    func testJobApplicationDefaultsOnEmptyJSON() throws {
+        let json = "{}"
+        let job = try JSONDecoder().decode(JobApplication.self, from: Data(json.utf8))
+        XCTAssertEqual(job.company, "")
+        XCTAssertEqual(job.title, "")
+        XCTAssertEqual(job.status, .wishlist)
+        XCTAssertEqual(job.excitement, 3)
+        XCTAssertFalse(job.isFavorite)
+        XCTAssertEqual(job.noteCards, [])
+    }
+
+    // MARK: - Computed Properties
+
+    func testDisplayTitleFallback() {
+        var job = JobApplication()
+        XCTAssertEqual(job.displayTitle, "Untitled Position")
+        job.title = "Engineer"
+        XCTAssertEqual(job.displayTitle, "Engineer")
+    }
+
+    func testDisplayCompanyFallback() {
+        var job = JobApplication()
+        XCTAssertEqual(job.displayCompany, "Unknown Company")
+        job.company = "Acme"
+        XCTAssertEqual(job.displayCompany, "Acme")
+    }
+
+    // MARK: - Color Hex
+
+    func testColorInitFromHexWithHash() {
+        let color = Color(hex: "#FF0000")
+        XCTAssertNotNil(color)
+    }
+
+    func testColorInitFromHexWithoutHash() {
+        let color = Color(hex: "00FF00")
+        XCTAssertNotNil(color)
+    }
+
+    func testColorInitFromInvalidHex() {
+        XCTAssertNil(Color(hex: "ZZZ"))
+        XCTAssertNil(Color(hex: "#12"))
+        XCTAssertNil(Color(hex: ""))
+    }
+
+    // MARK: - String.wordCount
+
+    func testWordCountEmpty() {
+        XCTAssertEqual("".wordCount, 0)
+    }
+
+    func testWordCountSingle() {
+        XCTAssertEqual("hello".wordCount, 1)
+    }
+
+    func testWordCountMulti() {
+        XCTAssertEqual("hello world foo".wordCount, 3)
+    }
+
+    func testWordCountWhitespaceHeavy() {
+        XCTAssertEqual("  hello   world  ".wordCount, 2)
+    }
+
+    // MARK: - AITokenUsage
+
+    func testAITokenUsageEstimatedCost() {
+        let usage = AITokenUsage(inputTokens: 1_000_000, outputTokens: 1_000_000)
+        // $3/MTok in + $15/MTok out = $18
+        XCTAssertEqual(usage.estimatedCost, 18.0, accuracy: 0.001)
+    }
+
+    func testAITokenUsageZero() {
+        XCTAssertEqual(AITokenUsage.zero.inputTokens, 0)
+        XCTAssertEqual(AITokenUsage.zero.outputTokens, 0)
+        XCTAssertEqual(AITokenUsage.zero.estimatedCost, 0.0)
+    }
+
+    func testAITokenUsageTotalTokens() {
+        let usage = AITokenUsage(inputTokens: 100, outputTokens: 200)
+        XCTAssertEqual(usage.totalTokens, 300)
+    }
+}

--- a/Tests/JobApplicationWizardTests/TestHelpers.swift
+++ b/Tests/JobApplicationWizardTests/TestHelpers.swift
@@ -1,0 +1,50 @@
+import Foundation
+@testable import JobApplicationWizardCore
+
+extension JobApplication {
+    static func mock(
+        id: UUID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+        company: String = "Acme Corp",
+        title: String = "Software Engineer",
+        url: String = "https://acme.com/jobs/1",
+        status: JobStatus = .wishlist,
+        dateAdded: Date = Date(timeIntervalSinceReferenceDate: 0),
+        dateApplied: Date? = nil,
+        salary: String = "$120k",
+        location: String = "Remote",
+        jobDescription: String = "Build cool stuff",
+        noteCards: [Note] = [],
+        resumeUsed: String = "",
+        coverLetter: String = "",
+        labels: [JobLabel] = [],
+        contacts: [Contact] = [],
+        interviews: [InterviewRound] = [],
+        isFavorite: Bool = false,
+        excitement: Int = 3,
+        hasPDF: Bool = false,
+        pdfPath: String? = nil
+    ) -> JobApplication {
+        var job = JobApplication()
+        job.id = id
+        job.company = company
+        job.title = title
+        job.url = url
+        job.status = status
+        job.dateAdded = dateAdded
+        job.dateApplied = dateApplied
+        job.salary = salary
+        job.location = location
+        job.jobDescription = jobDescription
+        job.noteCards = noteCards
+        job.resumeUsed = resumeUsed
+        job.coverLetter = coverLetter
+        job.labels = labels
+        job.contacts = contacts
+        job.interviews = interviews
+        job.isFavorite = isFavorite
+        job.excitement = excitement
+        job.hasPDF = hasPDF
+        job.pdfPath = pdfPath
+        return job
+    }
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive test suite covering all three TCA features, model/Codable logic, and CSV import/export — taking the project from **zero tests to 85 passing tests**.

To make this possible, the app's source code is extracted into a `JobApplicationWizardCore` library target (Swift 5.9 test targets cannot depend on executable targets). The executable target now contains only `App.swift`.

## What changed

### Structural: library extraction
- **`Sources/JobApplicationWizardCore/`** — new library target with all models, features, views, and dependency clients
- **`Sources/JobApplicationWizard/`** — executable keeps only `App.swift`, now imports the core library
- **`Tests/JobApplicationWizardTests/`** — new test target with 6 test files
- **`Package.swift`** — updated with three targets: library → executable → test

### Source-level changes (non-test)
- All public API types, properties, initializers, and methods marked `public` for cross-module visibility
- Added `@CasePathable` to `AddJobFeature.Action.Delegate` and `JobDetailFeature.Action.Delegate` for test key path matching
- Added `TestDependencyKey` with `unimplemented` closures to all 4 dependency clients (ClaudeClient, PersistenceClient, PDFClient, KeychainClient)

### Test files

| File | Tests | What's covered |
|------|:-----:|----------------|
| **ModelTests.swift** | 20 | Codable round-trips (JobApplication, AppSettings), legacy `notes` → `noteCards` migration, unknown-key tolerance, empty-JSON defaults, `displayTitle`/`displayCompany` fallbacks, `Color(hex:)` init, `String.wordCount`, `AITokenUsage` cost formula |
| **CSVTests.swift** | 13 | Export/import round-trips (single, multiple, with labels/contacts/interviews/noteCards), embedded commas/newlines/escaped quotes, empty & header-only CSV, invalid-row skipping, descending date sort order |
| **AddJobFeatureTests.swift** | 6 | `canSave` validation, `toggleLabel` add/remove, `setExcitement`, `saveTapped` builds job & delegates, applied status sets `dateApplied`, `cancelTapped` delegates |
| **AppFeatureTests.swift** | 19 | `onAppear` loads jobs/settings/API key, empty jobs triggers onboarding, search & filter, `selectJob`/nil, `moveJob` with `dateApplied`, syncs to jobDetail, `deleteJob` clears selection, `toggleFavorite`, addJob save/cancel delegation, jobDetail updated/deleted delegation, CSV import merges & skips duplicates, `saveSettingsKey` syncs, `saveProfile` syncs, `resetAllData` |
| **JobDetailFeatureTests.swift** | 27 | State init field mapping, `syncJobFromFields`, tab selection, excitement, favorite, `moveJob`, `markApplied`, delete flow (tapped → confirm/cancel), note/contact/interview CRUD (add & delete), AI chat send/response/error/empty-input/clear/token accumulation, PDF save success/failure, view with/without path |
| **TestHelpers.swift** | — | `JobApplication.mock(...)` factory with stable UUIDs and dates |

### Design decisions
- **`Date()` in reducers**: Tests that exercise `moveJob`, `markApplied`, and `addNote` use non-exhaustive assertion (`store.exhaustivity = .off`) and verify state after the fact, avoiding the need to inject `@Dependency(\.date)` (scope creep)
- **`Result<(String, AITokenUsage), Error>` key paths**: A Swift 6.2 compiler crash prevents using `\.aiResponseReceived.success` with tuple associated values; worked around with `\.aiResponseReceived` + post-hoc assertions
- **CSV functions**: Tested indirectly through `PersistenceClient.liveValue.exportCSV`/`importCSV` closures (pure functions, no disk I/O) — no visibility changes needed

## Test plan

- [x] `swift test` — 85 tests, 0 failures
- [x] `swift build` — app builds successfully
- [x] Launch app from Xcode and verify runtime behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)