### PR TITLE
Fix deprecated unimplemented() warnings

### DIFF
--- a/Sources/JobApplicationWizardCore/Dependencies/ClaudeClient.swift
+++ b/Sources/JobApplicationWizardCore/Dependencies/ClaudeClient.swift
@@ -112,7 +112,7 @@ public enum AIError: LocalizedError {
 
 extension ClaudeClient: TestDependencyKey {
     public static let testValue = ClaudeClient(
-        chat: unimplemented("\(Self.self).chat")
+        chat: unimplemented("\(Self.self).chat", placeholder: ("", .zero))
     )
 }
 

--- a/Sources/JobApplicationWizardCore/Dependencies/KeychainClient.swift
+++ b/Sources/JobApplicationWizardCore/Dependencies/KeychainClient.swift
@@ -60,8 +60,8 @@ extension KeychainClient: DependencyKey {
 
 extension KeychainClient: TestDependencyKey {
     public static let testValue = KeychainClient(
-        loadAPIKey: unimplemented("\(Self.self).loadAPIKey"),
-        saveAPIKey: unimplemented("\(Self.self).saveAPIKey")
+        loadAPIKey: unimplemented("\(Self.self).loadAPIKey", placeholder: ""),
+        saveAPIKey: unimplemented("\(Self.self).saveAPIKey", placeholder: ())
     )
 }
 

--- a/Sources/JobApplicationWizardCore/Dependencies/PDFClient.swift
+++ b/Sources/JobApplicationWizardCore/Dependencies/PDFClient.swift
@@ -112,9 +112,9 @@ private func buildTextView(for job: JobApplication) -> NSTextView {
 
 extension PDFClient: TestDependencyKey {
     public static let testValue = PDFClient(
-        printJobDescription: unimplemented("\(Self.self).printJobDescription"),
-        generateAndSavePDF: unimplemented("\(Self.self).generateAndSavePDF"),
-        openPDF: unimplemented("\(Self.self).openPDF")
+        printJobDescription: unimplemented("\(Self.self).printJobDescription", placeholder: ()),
+        generateAndSavePDF: unimplemented("\(Self.self).generateAndSavePDF", placeholder: ""),
+        openPDF: unimplemented("\(Self.self).openPDF", placeholder: ())
     )
 }
 

--- a/Sources/JobApplicationWizardCore/Dependencies/PersistenceClient.swift
+++ b/Sources/JobApplicationWizardCore/Dependencies/PersistenceClient.swift
@@ -270,14 +270,14 @@ extension PersistenceClient: DependencyKey {
 
 extension PersistenceClient: TestDependencyKey {
     public static let testValue = PersistenceClient(
-        loadJobs: unimplemented("\(Self.self).loadJobs"),
-        saveJobs: unimplemented("\(Self.self).saveJobs"),
-        loadSettings: unimplemented("\(Self.self).loadSettings"),
-        saveSettings: unimplemented("\(Self.self).saveSettings"),
-        exportCSV: unimplemented("\(Self.self).exportCSV"),
-        showCSVSavePanel: unimplemented("\(Self.self).showCSVSavePanel"),
-        showCSVOpenPanel: unimplemented("\(Self.self).showCSVOpenPanel"),
-        importCSV: unimplemented("\(Self.self).importCSV")
+        loadJobs: unimplemented("\(Self.self).loadJobs", placeholder: []),
+        saveJobs: unimplemented("\(Self.self).saveJobs", placeholder: ()),
+        loadSettings: unimplemented("\(Self.self).loadSettings", placeholder: AppSettings()),
+        saveSettings: unimplemented("\(Self.self).saveSettings", placeholder: ()),
+        exportCSV: unimplemented("\(Self.self).exportCSV", placeholder: ""),
+        showCSVSavePanel: unimplemented("\(Self.self).showCSVSavePanel", placeholder: ()),
+        showCSVOpenPanel: unimplemented("\(Self.self).showCSVOpenPanel", placeholder: nil),
+        importCSV: unimplemented("\(Self.self).importCSV", placeholder: [])
     )
 }
 


### PR DESCRIPTION
## Summary
- Replace deprecated `unimplemented(_:file:fileID:function:line:)` with `unimplemented(_:placeholder:)` across all 4 dependency clients (ClaudeClient, KeychainClient, PDFClient, PersistenceClient)
- Zero warnings on clean build

## Test plan
- [x] `swift build` produces no warnings locally
- [x] CI passes (build + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)