### PR TITLE
Add proposal workflow: Discussions to Issues pipeline

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: Questions & Discussion
     url: https://github.com/zacspa/JobApplicationWizard/discussions
     about: Ask questions, share ideas, or start a conversation
+  - name: Start a Proposal
+    url: https://github.com/zacspa/JobApplicationWizard/discussions/categories/proposals
+    about: Propose a significant change — discuss with the community before opening an issue

--- a/.github/ISSUE_TEMPLATE/proposal.yml
+++ b/.github/ISSUE_TEMPLATE/proposal.yml
@@ -1,0 +1,53 @@
+name: Proposal
+description: Propose a significant change or new direction (start in Discussions first)
+labels: ["proposal"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Before opening a proposal issue
+
+        Proposals should start as a [Discussion](https://github.com/zacspa/JobApplicationWizard/discussions/categories/proposals) so the community can weigh in. Open an issue here once the proposal has been discussed and accepted.
+  - type: input
+    id: discussion-link
+    attributes:
+      label: Discussion Link
+      description: Link to the original Discussion thread
+      placeholder: https://github.com/zacspa/JobApplicationWizard/discussions/...
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Brief description of the proposal and what was decided in the discussion
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this change needed? What problem does it solve?
+    validations:
+      required: true
+  - type: textarea
+    id: design
+    attributes:
+      label: Design
+      description: How should this be implemented? Include key technical decisions.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope & Milestones
+      description: What are the concrete steps or PRs needed to complete this?
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Interested in contributing?
+      options:
+        - I'd like to implement this
+        - I can help with design/UX
+        - I can help test
+        - I'm just proposing

--- a/.github/workflows/proposal-accepted.yml
+++ b/.github/workflows/proposal-accepted.yml
@@ -1,0 +1,49 @@
+name: Proposal Accepted
+
+on:
+  discussion:
+    types: [labeled]
+
+jobs:
+  create-issue:
+    if: github.event.label.name == 'accepted'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      discussions: write
+    steps:
+      - name: Create issue from proposal
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const discussion = context.payload.discussion;
+
+            const issueBody = [
+              `## Summary`,
+              ``,
+              discussion.body,
+              ``,
+              `---`,
+              ``,
+              `**Proposal Discussion:** ${discussion.html_url}`,
+              `**Proposed by:** @${discussion.user.login}`,
+            ].join('\n');
+
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: discussion.title,
+              body: issueBody,
+              labels: ['proposal'],
+            });
+
+            await github.graphql(`
+              mutation($discussionId: ID!, $body: String!) {
+                addDiscussionComment(input: { discussionId: $discussionId, body: $body }) {
+                  comment { id }
+                }
+              }
+            `, {
+              discussionId: discussion.node_id,
+              body: `This proposal has been accepted! Tracking issue: ${issue.data.html_url}`,
+            });


### PR DESCRIPTION
## Summary

Adds a structured proposal workflow so community members can propose significant changes through GitHub Discussions, and maintainers can promote accepted proposals to trackable issues with a single label.

## What's included

### 1. Proposal issue template (`.github/ISSUE_TEMPLATE/proposal.yml`)
- Form fields: discussion link (required), summary, motivation, design, scope & milestones
- Includes a callout reminding contributors to start in Discussions first
- Labels issues with `proposal`

### 2. Issue picker config update (`.github/ISSUE_TEMPLATE/config.yml`)
- Adds a "Start a Proposal" link pointing to the Proposals discussion category
- Guides contributors to discuss before opening an issue

### 3. Automated discussion-to-issue workflow (`.github/workflows/proposal-accepted.yml`)
- Triggers when a maintainer adds the `accepted` label to a discussion
- Automatically creates an issue with:
  - The discussion title and body
  - A link back to the original discussion
  - Credit to the original proposer (`@username`)
  - The `proposal` label
- Comments on the discussion with a link to the new tracking issue

## Intended flow

1. Community member posts a proposal in **Discussions > Proposals**
2. Community discusses, reacts, iterates
3. Maintainer adds the `accepted` label to the discussion
4. GitHub Action auto-creates a tracking issue and links it back
5. Implementation begins via PRs referencing the issue

## Setup needed after merge

- [ ] Create a "Proposals" discussion category: **Repo Settings > Discussions > New category** (📜 scroll emoji, non-answerable)
- [ ] Create the `accepted` label: **Issues > Labels > New label** (or it auto-creates on first use)

## Test plan

- [ ] Verify proposal issue template renders in the issue picker
- [ ] Verify "Start a Proposal" link appears in the issue picker
- [ ] Create a test discussion, add the `accepted` label, and confirm the workflow creates an issue and comments back

🤖 Generated with [Claude Code](https://claude.com/claude-code)