### PR TITLE
feat: add per-status subtasks to job applications

### DIFF
--- a/Sources/JobApplicationWizardCore/Features/JobDetail/JobDetailFeature.swift
+++ b/Sources/JobApplicationWizardCore/Features/JobDetail/JobDetailFeature.swift
@@ -25,6 +25,10 @@ public struct JobDetailFeature {
         // UI state
         public var selectedTab: Tab = .overview
         public var showDeleteConfirm: Bool = false
+        public var pendingStatusChange: JobStatus? = nil
+        public var showIncompleteTasksAlert: Bool = false
+        public var newTaskText: String = ""
+        public var isAddingTask: Bool = false
 
         // PDF state
         public var isGeneratingPDF: Bool = false
@@ -101,8 +105,19 @@ public struct JobDetailFeature {
         case selectTab(State.Tab)
         case setExcitement(Int)
         case toggleFavorite
+        case moveJobRequested(JobStatus)
+        case moveJobAlertContinue
+        case moveJobAlertCancel
         case moveJob(JobStatus)
         case markApplied
+        // Tasks
+        case toggleTask(UUID)
+        case deleteTask(UUID)
+        case addTaskTapped
+        case newTaskTextChanged(String)
+        case saveNewTask
+        case cancelNewTask
+        case addSuggestedTask(String)
         case deleteTapped
         case deleteConfirmed
         case deleteCancelled
@@ -158,6 +173,26 @@ public struct JobDetailFeature {
             case .toggleFavorite:
                 state.job.isFavorite.toggle()
                 return .send(.delegate(.jobUpdated(state.job)))
+
+            case .moveJobRequested(let status):
+                if !state.job.hasIncompleteCurrentTasks {
+                    return .send(.moveJob(status))
+                } else {
+                    state.pendingStatusChange = status
+                    state.showIncompleteTasksAlert = true
+                    return .none
+                }
+
+            case .moveJobAlertContinue:
+                guard let status = state.pendingStatusChange else { return .none }
+                state.pendingStatusChange = nil
+                state.showIncompleteTasksAlert = false
+                return .send(.moveJob(status))
+
+            case .moveJobAlertCancel:
+                state.pendingStatusChange = nil
+                state.showIncompleteTasksAlert = false
+                return .none
 
             case .moveJob(let status):
                 state.job.status = status
@@ -261,6 +296,45 @@ public struct JobDetailFeature {
                 state.isGeneratingPDF = false
                 state.pdfError = error.localizedDescription
                 return .none
+
+            case .toggleTask(let taskID):
+                if let idx = state.job.tasks.firstIndex(where: { $0.id == taskID }) {
+                    state.job.tasks[idx].isCompleted.toggle()
+                }
+                return .send(.delegate(.jobUpdated(state.job)))
+
+            case .deleteTask(let taskID):
+                state.job.tasks.removeAll { $0.id == taskID }
+                return .send(.delegate(.jobUpdated(state.job)))
+
+            case .addTaskTapped:
+                state.isAddingTask = true
+                return .none
+
+            case .newTaskTextChanged(let text):
+                state.newTaskText = text
+                return .none
+
+            case .saveNewTask:
+                let text = state.newTaskText.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !text.isEmpty else {
+                    state.isAddingTask = false
+                    state.newTaskText = ""
+                    return .none
+                }
+                state.job.tasks.append(SubTask(title: text, forStatus: state.job.status))
+                state.isAddingTask = false
+                state.newTaskText = ""
+                return .send(.delegate(.jobUpdated(state.job)))
+
+            case .cancelNewTask:
+                state.isAddingTask = false
+                state.newTaskText = ""
+                return .none
+
+            case .addSuggestedTask(let title):
+                state.job.tasks.append(SubTask(title: title, forStatus: state.job.status))
+                return .send(.delegate(.jobUpdated(state.job)))
 
             case .delegate:
                 return .none

--- a/Sources/JobApplicationWizardCore/JobDetailView.swift
+++ b/Sources/JobApplicationWizardCore/JobDetailView.swift
@@ -28,6 +28,15 @@ public struct JobDetailView: View {
         } message: {
             Text("Delete \(store.job.displayTitle) at \(store.job.displayCompany)? This cannot be undone.")
         }
+        .alert("Incomplete Tasks", isPresented: Binding(
+            get: { store.showIncompleteTasksAlert },
+            set: { if !$0 { store.send(.moveJobAlertCancel) } }
+        )) {
+            Button("Continue Anyway", role: .destructive) { store.send(.moveJobAlertContinue) }
+            Button("Cancel", role: .cancel) { store.send(.moveJobAlertCancel) }
+        } message: {
+            Text("You have incomplete tasks for this stage. Move anyway?")
+        }
     }
 
     var tabBar: some View {
@@ -91,7 +100,7 @@ public struct JobDetailView: View {
 
                     Menu {
                         ForEach(JobStatus.allCases) { s in
-                            Button { store.send(.moveJob(s)) } label: {
+                            Button { store.send(.moveJobRequested(s)) } label: {
                                 Label(s.rawValue, systemImage: s.icon)
                             }
                         }
@@ -271,6 +280,41 @@ struct OverviewTab: View {
     }
 }
 
+// MARK: - Task Row
+
+struct TaskRowView: View {
+    let task: SubTask
+    let onToggle: () -> Void
+    let onDelete: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack {
+            Button(action: onToggle) {
+                Image(systemName: task.isCompleted ? "checkmark.circle.fill" : "circle")
+                    .foregroundColor(task.isCompleted ? .green : .secondary)
+            }
+            .buttonStyle(.plain)
+            Text(task.title)
+                .font(.subheadline)
+                .strikethrough(task.isCompleted)
+                .foregroundColor(task.isCompleted ? .secondary : .primary)
+            Spacer()
+            if isHovered {
+                Button(action: onDelete) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary.opacity(0.6))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.vertical, 5)
+        .padding(.horizontal, 8)
+        .contentShape(Rectangle())
+        .onHover { isHovered = $0 }
+    }
+}
+
 // MARK: - Detail Row helper
 
 struct DetailRow<Content: View>: View {
@@ -430,80 +474,220 @@ struct NotesTab: View {
     ]
 
     var body: some View {
-        if let noteID = selectedNoteID,
-           store.noteCards.contains(where: { $0.id == noteID }) {
-            NoteEditorView(
-                note: Binding(
-                    get: { store.noteCards.first(where: { $0.id == noteID }) ?? Note() },
-                    set: { new in
-                        var updated = new
-                        updated.updatedAt = Date()
-                        var copy = store.noteCards
-                        if let idx = copy.firstIndex(where: { $0.id == updated.id }) {
-                            copy[idx] = updated
-                            store.send(.binding(.set(\.noteCards, copy)))
-                        }
-                    }
-                ),
-                onBack: { selectedNoteID = nil },
-                onDelete: {
-                    store.send(.deleteNote(noteID))
-                    selectedNoteID = nil
-                }
-            )
-        } else {
-            NoteCardGridView(
-                store: store,
-                cardColors: NotesTab.cardColors,
-                onSelectNote: { selectedNoteID = $0 }
-            )
+        ScrollView {
+            VStack(spacing: 16) {
+                TasksSectionView(store: store)
+                NotesSectionView(
+                    store: store,
+                    cardColors: NotesTab.cardColors,
+                    selectedNoteID: $selectedNoteID
+                )
+            }
+            .padding(16)
         }
     }
 }
 
-// MARK: - Note Card Grid
+// MARK: - Tasks Section (grouped by status phase)
 
-struct NoteCardGridView: View {
+struct TasksSectionView: View {
     @Bindable var store: StoreOf<JobDetailFeature>
-    let cardColors: [Color]
-    let onSelectNote: (UUID) -> Void
+
+    /// Statuses that have tasks, with the current status always first
+    private var statusesWithTasks: [JobStatus] {
+        let current = store.job.status
+        var statuses = JobStatus.allCases.filter { status in
+            store.job.tasks.contains { $0.forStatus == status }
+        }
+        // Always include current status so user can add tasks even if none exist yet
+        if !statuses.contains(current) {
+            statuses.append(current)
+        }
+        // Sort: current status first, then by allCases order
+        statuses.sort { a, b in
+            if a == current { return true }
+            if b == current { return false }
+            return (JobStatus.allCases.firstIndex(of: a) ?? 0) < (JobStatus.allCases.firstIndex(of: b) ?? 0)
+        }
+        return statuses
+    }
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
             HStack {
-                Text("Notes about this application")
-                    .font(.footnote).foregroundColor(.secondary)
+                let totalRemaining = store.job.tasks.filter { !$0.isCompleted }.count
+                Text(totalRemaining > 0 ? "Tasks (\(totalRemaining) remaining)" : "Tasks")
+                    .font(.headline)
                 Spacer()
-                Button { store.send(.addNote) } label: {
-                    Label("New Note", systemImage: "plus").font(.footnote)
+                if !store.isAddingTask {
+                    Button { store.send(.addTaskTapped) } label: {
+                        Label("Add Task", systemImage: "plus").font(.footnote)
+                    }
+                    .buttonStyle(.bordered).controlSize(.mini)
                 }
-                .buttonStyle(.bordered).controlSize(.mini)
             }
-            .padding(.horizontal, 16).padding(.vertical, 8)
-            .background(Color(NSColor.controlBackgroundColor))
+            .padding(.bottom, 10)
 
-            Divider()
-
-            if store.noteCards.isEmpty {
-                Spacer()
-                ContentUnavailableView(
-                    "No Notes Yet",
-                    systemImage: "note.text",
-                    description: Text("Add your first note to capture research, salary info, or anything relevant")
-                )
-                Spacer()
-            } else {
-                ScrollView {
-                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 180))], spacing: 12) {
-                        ForEach(store.noteCards) { note in
-                            NoteCard(
-                                note: note,
-                                accentColor: cardColors[abs(note.id.hashValue) % cardColors.count],
-                                onTap: { onSelectNote(note.id) }
-                            )
+            // Add task UI (adds to current status)
+            if store.isAddingTask {
+                VStack(alignment: .leading, spacing: 8) {
+                    let suggestions = store.job.status.suggestedTaskTitles.filter { s in
+                        !store.job.tasks.contains { $0.title == s && $0.forStatus == store.job.status }
+                    }
+                    if !suggestions.isEmpty {
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 6) {
+                                ForEach(suggestions, id: \.self) { suggestion in
+                                    Button { store.send(.addSuggestedTask(suggestion)) } label: {
+                                        Text("+ \(suggestion)")
+                                            .font(.footnote)
+                                            .padding(.horizontal, 8)
+                                            .padding(.vertical, 4)
+                                            .background(Color.accentColor.opacity(0.1))
+                                            .foregroundColor(.accentColor)
+                                            .clipShape(Capsule())
+                                    }
+                                    .buttonStyle(.plain)
+                                }
+                            }
                         }
                     }
-                    .padding(16)
+                    HStack {
+                        TextField("Task title...", text: Binding(
+                            get: { store.newTaskText },
+                            set: { store.send(.newTaskTextChanged($0)) }
+                        ))
+                        .textFieldStyle(.roundedBorder)
+                        .font(.subheadline)
+                        .onSubmit { store.send(.saveNewTask) }
+                        Button("Save") { store.send(.saveNewTask) }
+                            .buttonStyle(.borderedProminent)
+                            .controlSize(.small)
+                            .disabled(store.newTaskText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        Button("Cancel") { store.send(.cancelNewTask) }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                    }
+                }
+                .padding(10)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Color(NSColor.controlBackgroundColor)))
+                .padding(.bottom, 8)
+            }
+
+            // Grouped by status
+            ForEach(statusesWithTasks) { status in
+                let tasksForStatus = store.job.tasks.filter { $0.forStatus == status }
+                let isCurrent = status == store.job.status
+
+                VStack(alignment: .leading, spacing: 0) {
+                    // Status group header
+                    HStack(spacing: 6) {
+                        Image(systemName: status.icon)
+                            .font(.caption)
+                            .foregroundColor(status.color)
+                        Text(status.rawValue)
+                            .font(.subheadline).fontWeight(.medium)
+                            .foregroundColor(isCurrent ? .primary : .secondary)
+                        if isCurrent {
+                            Text("current")
+                                .font(.system(size: 9, weight: .medium))
+                                .padding(.horizontal, 5).padding(.vertical, 1)
+                                .background(status.color.opacity(0.15))
+                                .foregroundColor(status.color)
+                                .clipShape(Capsule())
+                        }
+                        Spacer()
+                        if !tasksForStatus.isEmpty {
+                            let done = tasksForStatus.filter { $0.isCompleted }.count
+                            Text("\(done)/\(tasksForStatus.count)")
+                                .font(.caption).foregroundColor(.secondary)
+                        }
+                    }
+                    .padding(.vertical, 6).padding(.horizontal, 8)
+
+                    if tasksForStatus.isEmpty {
+                        Text("No tasks")
+                            .font(.caption).foregroundColor(.secondary)
+                            .padding(.horizontal, 8).padding(.bottom, 6)
+                    } else {
+                        ForEach(tasksForStatus) { task in
+                            TaskRowView(
+                                task: task,
+                                onToggle: { store.send(.toggleTask(task.id)) },
+                                onDelete: { store.send(.deleteTask(task.id)) }
+                            )
+                            if task.id != tasksForStatus.last?.id {
+                                Divider().padding(.leading, 32)
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+                .background(RoundedRectangle(cornerRadius: 8).fill(
+                    isCurrent ? Color(NSColor.controlBackgroundColor) : Color.clear
+                ))
+            }
+        }
+    }
+}
+
+// MARK: - Notes Section
+
+struct NotesSectionView: View {
+    @Bindable var store: StoreOf<JobDetailFeature>
+    let cardColors: [Color]
+    @Binding var selectedNoteID: UUID?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if selectedNoteID == nil {
+                HStack {
+                    Text("Notes")
+                        .font(.headline)
+                    Spacer()
+                    Button { store.send(.addNote) } label: {
+                        Label("New Note", systemImage: "plus").font(.footnote)
+                    }
+                    .buttonStyle(.bordered).controlSize(.mini)
+                }
+            }
+
+            if let noteID = selectedNoteID,
+               store.noteCards.contains(where: { $0.id == noteID }) {
+                NoteEditorView(
+                    note: Binding(
+                        get: { store.noteCards.first(where: { $0.id == noteID }) ?? Note() },
+                        set: { new in
+                            var updated = new
+                            updated.updatedAt = Date()
+                            var copy = store.noteCards
+                            if let idx = copy.firstIndex(where: { $0.id == updated.id }) {
+                                copy[idx] = updated
+                                store.send(.binding(.set(\.noteCards, copy)))
+                            }
+                        }
+                    ),
+                    onBack: { selectedNoteID = nil },
+                    onDelete: {
+                        store.send(.deleteNote(noteID))
+                        selectedNoteID = nil
+                    }
+                )
+            } else if store.noteCards.isEmpty {
+                Text("No notes yet — add one to capture research, salary info, or anything relevant.")
+                    .font(.subheadline).foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 20)
+            } else {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 180))], spacing: 12) {
+                    ForEach(store.noteCards) { note in
+                        NoteCard(
+                            note: note,
+                            accentColor: cardColors[abs(note.id.hashValue) % cardColors.count],
+                            onTap: { selectedNoteID = note.id }
+                        )
+                    }
                 }
             }
         }

--- a/Sources/JobApplicationWizardCore/KanbanView.swift
+++ b/Sources/JobApplicationWizardCore/KanbanView.swift
@@ -176,6 +176,8 @@ struct JobCard: View {
     let onDelete: () -> Void
 
     @State private var isHovered = false
+    @State private var showTaskPopover = false
+    @State private var hoverTimer: Task<Void, Never>? = nil
 
     var body: some View {
         Button(action: onSelect) {
@@ -244,6 +246,14 @@ struct JobCard: View {
                             .foregroundColor(.secondary)
                     }
                     Spacer()
+                    if !job.currentTasks.isEmpty {
+                        let done = job.currentTasks.filter { $0.isCompleted }.count
+                        let total = job.currentTasks.count
+                        let allDone = done == total
+                        Label("\(done)/\(total)", systemImage: allDone ? "checkmark.circle.fill" : "checklist")
+                            .font(.caption2)
+                            .foregroundColor(allDone ? .green : .secondary)
+                    }
                     if !job.contacts.isEmpty {
                         Label("\(job.contacts.count)", systemImage: "person.circle")
                             .font(.caption2)
@@ -269,7 +279,25 @@ struct JobCard: View {
             .shadow(color: .black.opacity(0.04), radius: 2, y: 1)
         }
         .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
+        .popover(isPresented: $showTaskPopover, arrowEdge: .bottom) {
+            TaskPopoverView(job: job)
+        }
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering {
+                hoverTimer = Task { @MainActor in
+                    try? await Task.sleep(for: .milliseconds(800))
+                    guard !Task.isCancelled else { return }
+                    if !job.currentTasks.isEmpty {
+                        showTaskPopover = true
+                    }
+                }
+            } else {
+                hoverTimer?.cancel()
+                hoverTimer = nil
+                showTaskPopover = false
+            }
+        }
         .contextMenu {
             Menu("Move to") {
                 ForEach(JobStatus.allCases) { s in
@@ -295,6 +323,35 @@ struct JobCard: View {
                 Label("Delete", systemImage: "trash")
             }
         }
+    }
+}
+
+// MARK: - Task Popover
+
+struct TaskPopoverView: View {
+    let job: JobApplication
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("\(job.status.rawValue) Tasks")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundColor(.secondary)
+                .padding(.bottom, 2)
+            ForEach(job.currentTasks) { task in
+                HStack(spacing: 6) {
+                    Image(systemName: task.isCompleted ? "checkmark.circle.fill" : "circle")
+                        .foregroundColor(task.isCompleted ? .green : .secondary)
+                        .font(.caption)
+                    Text(task.title)
+                        .font(.caption)
+                        .foregroundColor(task.isCompleted ? .secondary : .primary)
+                        .strikethrough(task.isCompleted)
+                }
+            }
+        }
+        .padding(12)
+        .frame(minWidth: 200)
     }
 }
 

--- a/Sources/JobApplicationWizardCore/Models.swift
+++ b/Sources/JobApplicationWizardCore/Models.swift
@@ -37,6 +37,17 @@ public enum JobStatus: String, Codable, CaseIterable, Identifiable, Equatable {
         case .withdrawn:   return "arrow.uturn.backward.circle.fill"
         }
     }
+
+    public var suggestedTaskTitles: [String] {
+        switch self {
+        case .wishlist:    return ["Research the company", "Check salary range", "Save job description"]
+        case .applied:     return ["Save application confirmation", "Follow up after 1 week"]
+        case .phoneScreen: return ["Research your interviewer", "Prepare elevator pitch", "Confirm call time and format"]
+        case .interview:   return ["Prepare STAR answers", "Research company culture", "Send thank-you note after"]
+        case .offer:       return ["Review offer details", "Research market salary", "Negotiate or accept"]
+        case .rejected, .withdrawn: return []
+        }
+    }
 }
 
 // MARK: - Label
@@ -111,6 +122,22 @@ public struct Contact: Codable, Identifiable, Equatable {
         self.linkedin = linkedin
         self.notes = notes
         self.connected = connected
+    }
+}
+
+// MARK: - SubTask
+
+public struct SubTask: Identifiable, Codable, Equatable {
+    public var id: UUID = UUID()
+    public var title: String
+    public var isCompleted: Bool = false
+    public var forStatus: JobStatus
+
+    public init(id: UUID = UUID(), title: String, isCompleted: Bool = false, forStatus: JobStatus) {
+        self.id = id
+        self.title = title
+        self.isCompleted = isCompleted
+        self.forStatus = forStatus
     }
 }
 
@@ -191,6 +218,7 @@ public struct JobApplication: Codable, Identifiable, Equatable {
     public var pdfPath: String? = nil
     public var chatHistory: [ChatMessage] = []
     public var documents: [JobDocument] = []
+    public var tasks: [SubTask] = []
 
     public var displayTitle: String {
         title.isEmpty ? "Untitled Position" : title
@@ -198,6 +226,14 @@ public struct JobApplication: Codable, Identifiable, Equatable {
 
     public var displayCompany: String {
         company.isEmpty ? "Unknown Company" : company
+    }
+
+    public var currentTasks: [SubTask] {
+        tasks.filter { $0.forStatus == status }
+    }
+
+    public var hasIncompleteCurrentTasks: Bool {
+        tasks.contains { $0.forStatus == status && !$0.isCompleted }
     }
 
     public init() {}
@@ -208,7 +244,7 @@ public struct JobApplication: Codable, Identifiable, Equatable {
         case id, company, title, url, status, dateAdded, dateApplied
         case salary, location, jobDescription, noteCards
         case resumeUsed, coverLetter, labels, contacts, interviews
-        case isFavorite, excitement, hasPDF, pdfPath, chatHistory, documents
+        case isFavorite, excitement, hasPDF, pdfPath, chatHistory, documents, tasks
         case legacyNotes = "notes"
     }
 
@@ -235,6 +271,7 @@ public struct JobApplication: Codable, Identifiable, Equatable {
         pdfPath      = try c.decodeIfPresent(String.self,          forKey: .pdfPath)
         chatHistory  = try c.decodeIfPresent([ChatMessage].self,   forKey: .chatHistory)  ?? []
         documents    = try c.decodeIfPresent([JobDocument].self,  forKey: .documents)    ?? []
+        tasks        = try c.decodeIfPresent([SubTask].self,        forKey: .tasks)        ?? []
 
         if let cards = try c.decodeIfPresent([Note].self, forKey: .noteCards) {
             noteCards = cards
@@ -273,6 +310,7 @@ public struct JobApplication: Codable, Identifiable, Equatable {
         if !documents.isEmpty {
             try c.encode(documents, forKey: .documents)
         }
+        try c.encode(tasks,          forKey: .tasks)
     }
 }
 

--- a/Tests/JobApplicationWizardTests/JobDetailFeatureTests.swift
+++ b/Tests/JobApplicationWizardTests/JobDetailFeatureTests.swift
@@ -587,4 +587,223 @@ final class JobDetailFeatureTests: XCTestCase {
         // Empty chatHistory should not be in JSON (we skip encoding it)
         XCTAssertFalse(json.contains("chatHistory"))
     }
+
+    // MARK: - moveJobRequested
+
+    func testMoveJobRequestedWithNoIncompleteTasks() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock(status: .wishlist))) {
+            JobDetailFeature()
+        }
+
+        store.exhaustivity = .off
+        await store.send(.moveJobRequested(.applied))
+        await store.receive(\.moveJob)
+
+        XCTAssertEqual(store.state.job.status, .applied)
+        XCTAssertFalse(store.state.showIncompleteTasksAlert)
+    }
+
+    func testMoveJobRequestedWithIncompleteTasksShowsAlert() async {
+        let task = SubTask(title: "Research company", isCompleted: false, forStatus: .wishlist)
+        let job = JobApplication.mock(status: .wishlist, tasks: [task])
+
+        let store = TestStore(initialState: JobDetailFeature.State(job: job)) {
+            JobDetailFeature()
+        }
+
+        await store.send(.moveJobRequested(.applied)) {
+            $0.pendingStatusChange = .applied
+            $0.showIncompleteTasksAlert = true
+        }
+
+        XCTAssertEqual(store.state.job.status, .wishlist)
+    }
+
+    func testMoveJobAlertContinueTransitionsStatus() async {
+        let task = SubTask(title: "Research company", isCompleted: false, forStatus: .wishlist)
+        let job = JobApplication.mock(status: .wishlist, tasks: [task])
+        var state = JobDetailFeature.State(job: job)
+        state.pendingStatusChange = .applied
+        state.showIncompleteTasksAlert = true
+
+        let store = TestStore(initialState: state) {
+            JobDetailFeature()
+        }
+
+        store.exhaustivity = .off
+        await store.send(.moveJobAlertContinue)
+        await store.receive(\.moveJob)
+
+        XCTAssertEqual(store.state.job.status, .applied)
+        XCTAssertFalse(store.state.showIncompleteTasksAlert)
+        XCTAssertNil(store.state.pendingStatusChange)
+    }
+
+    func testMoveJobAlertCancelLeavesStatusUnchanged() async {
+        let task = SubTask(title: "Research company", isCompleted: false, forStatus: .wishlist)
+        let job = JobApplication.mock(status: .wishlist, tasks: [task])
+        var state = JobDetailFeature.State(job: job)
+        state.pendingStatusChange = .applied
+        state.showIncompleteTasksAlert = true
+
+        let store = TestStore(initialState: state) {
+            JobDetailFeature()
+        }
+
+        await store.send(.moveJobAlertCancel) {
+            $0.pendingStatusChange = nil
+            $0.showIncompleteTasksAlert = false
+        }
+
+        XCTAssertEqual(store.state.job.status, .wishlist)
+    }
+
+    // MARK: - Task CRUD
+
+    func testToggleTaskCompletesIt() async {
+        let taskID = UUID(uuidString: "00000000-0000-0000-0000-000000000099")!
+        let task = SubTask(id: taskID, title: "Research company", isCompleted: false, forStatus: .wishlist)
+        let job = JobApplication.mock(tasks: [task])
+
+        let store = TestStore(initialState: JobDetailFeature.State(job: job)) {
+            JobDetailFeature()
+        }
+
+        await store.send(.toggleTask(taskID)) {
+            $0.job.tasks[0].isCompleted = true
+        }
+        await store.receive(\.delegate.jobUpdated)
+    }
+
+    func testToggleTaskUnchecksCompleted() async {
+        let taskID = UUID(uuidString: "00000000-0000-0000-0000-000000000099")!
+        let task = SubTask(id: taskID, title: "Research company", isCompleted: true, forStatus: .wishlist)
+        let job = JobApplication.mock(tasks: [task])
+
+        let store = TestStore(initialState: JobDetailFeature.State(job: job)) {
+            JobDetailFeature()
+        }
+
+        await store.send(.toggleTask(taskID)) {
+            $0.job.tasks[0].isCompleted = false
+        }
+        await store.receive(\.delegate.jobUpdated)
+    }
+
+    func testDeleteTask() async {
+        let taskID = UUID(uuidString: "00000000-0000-0000-0000-000000000099")!
+        let task = SubTask(id: taskID, title: "Research company", isCompleted: false, forStatus: .wishlist)
+        let job = JobApplication.mock(tasks: [task])
+
+        let store = TestStore(initialState: JobDetailFeature.State(job: job)) {
+            JobDetailFeature()
+        }
+
+        await store.send(.deleteTask(taskID)) {
+            $0.job.tasks = []
+        }
+        await store.receive(\.delegate.jobUpdated)
+    }
+
+    func testAddTaskTapped() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock())) {
+            JobDetailFeature()
+        }
+
+        await store.send(.addTaskTapped) {
+            $0.isAddingTask = true
+        }
+    }
+
+    func testSaveNewTask() async {
+        var state = JobDetailFeature.State(job: .mock(status: .wishlist))
+        state.isAddingTask = true
+        state.newTaskText = "My custom task"
+
+        let store = TestStore(initialState: state) {
+            JobDetailFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.saveNewTask)
+        await store.receive(\.delegate.jobUpdated)
+
+        XCTAssertFalse(store.state.isAddingTask)
+        XCTAssertEqual(store.state.newTaskText, "")
+        XCTAssertEqual(store.state.job.tasks.count, 1)
+        XCTAssertEqual(store.state.job.tasks[0].title, "My custom task")
+        XCTAssertFalse(store.state.job.tasks[0].isCompleted)
+        XCTAssertEqual(store.state.job.tasks[0].forStatus, .wishlist)
+    }
+
+    func testSaveNewTaskWithEmptyTextCancels() async {
+        var state = JobDetailFeature.State(job: .mock())
+        state.isAddingTask = true
+        state.newTaskText = "   "
+
+        let store = TestStore(initialState: state) {
+            JobDetailFeature()
+        }
+
+        await store.send(.saveNewTask) {
+            $0.isAddingTask = false
+            $0.newTaskText = ""
+        }
+    }
+
+    func testCancelNewTask() async {
+        var state = JobDetailFeature.State(job: .mock())
+        state.isAddingTask = true
+        state.newTaskText = "partial"
+
+        let store = TestStore(initialState: state) {
+            JobDetailFeature()
+        }
+
+        await store.send(.cancelNewTask) {
+            $0.isAddingTask = false
+            $0.newTaskText = ""
+        }
+    }
+
+    func testAddSuggestedTask() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock(status: .wishlist))) {
+            JobDetailFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.addSuggestedTask("Research the company"))
+        await store.receive(\.delegate.jobUpdated)
+
+        XCTAssertEqual(store.state.job.tasks.count, 1)
+        XCTAssertEqual(store.state.job.tasks[0].title, "Research the company")
+        XCTAssertFalse(store.state.job.tasks[0].isCompleted)
+        XCTAssertEqual(store.state.job.tasks[0].forStatus, .wishlist)
+    }
+
+    func testNewTaskTextChanged() async {
+        let store = TestStore(initialState: JobDetailFeature.State(job: .mock())) {
+            JobDetailFeature()
+        }
+
+        await store.send(.newTaskTextChanged("Schedule follow-up call")) {
+            $0.newTaskText = "Schedule follow-up call"
+        }
+    }
+
+    func testMoveJobRequestedWithCompletedTasksProceedsImmediately() async {
+        let task = SubTask(title: "Research the company", isCompleted: true, forStatus: .wishlist)
+        let job = JobApplication.mock(status: .wishlist, tasks: [task])
+
+        let store = TestStore(initialState: JobDetailFeature.State(job: job)) {
+            JobDetailFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.moveJobRequested(.applied))
+        await store.receive(\.moveJob)
+
+        XCTAssertEqual(store.state.job.status, .applied)
+        XCTAssertFalse(store.state.showIncompleteTasksAlert)
+    }
 }

--- a/Tests/JobApplicationWizardTests/TestHelpers.swift
+++ b/Tests/JobApplicationWizardTests/TestHelpers.swift
@@ -24,7 +24,8 @@ extension JobApplication {
         hasPDF: Bool = false,
         pdfPath: String? = nil,
         chatHistory: [ChatMessage] = [],
-        documents: [JobDocument] = []
+        documents: [JobDocument] = [],
+        tasks: [SubTask] = []
     ) -> JobApplication {
         var job = JobApplication()
         job.id = id
@@ -49,6 +50,7 @@ extension JobApplication {
         job.pdfPath = pdfPath
         job.chatHistory = chatHistory
         job.documents = documents
+        job.tasks = tasks
         return job
     }
 }


### PR DESCRIPTION
## What
Introduces a model and UI to manage subtasks in each job state. 

## Why
Allows an applicant to track what might need to be done before the application can move to the next state. i.e. setup interview times.

## How
Introduces a SubTask model (title, completion state, status scope) stored on each JobApplication.

## Testing
- [x] `swift test` passes locally
- [x] Tested in the app (describe what you did)

## Screenshots

https://github.com/user-attachments/assets/4e4451e6-e8b5-489c-99d6-6f7d9fe3d1eb



## Checklist
- [x] Commits follow `type: description` convention
- [x] I have read CONTRIBUTING.md
