### PR TITLE
Fix right pane min widths, text truncation, ACP cleanup

### DIFF
--- a/Sources/JobApplicationWizard/App.swift
+++ b/Sources/JobApplicationWizard/App.swift
@@ -8,6 +8,8 @@ import JobApplicationWizardCore
 
 #if os(macOS)
 class AppDelegate: NSObject, NSApplicationDelegate {
+    var store: StoreOf<AppFeature>?
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Set activation policy and bring window to front
         NSApp.setActivationPolicy(.regular)
@@ -15,6 +17,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             NSApp.activate(ignoringOtherApps: true)
             NSApp.windows.first?.makeKeyAndOrderFront(nil)
         }
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        // Synchronously disconnect the ACP agent so the child process doesn't outlive the app.
+        let semaphore = DispatchSemaphore(value: 0)
+        Task {
+            store?.send(.disconnectACPAgent)
+            // Give the disconnect a moment to terminate the process.
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            semaphore.signal()
+        }
+        semaphore.wait()
     }
 }
 #endif
@@ -43,7 +57,8 @@ struct JobApplicationWizardApp: App {
     var body: some Scene {
         WindowGroup(id: "main") {
             ContentView(store: store)
-                .frame(minWidth: 960, minHeight: 600)
+                .frame(minWidth: 1200, minHeight: 600)
+                .onAppear { appDelegate.store = store }
         }
         .defaultSize(width: 1440, height: 900)
         .windowStyle(.titleBar)

--- a/Sources/JobApplicationWizardCore/ContentView.swift
+++ b/Sources/JobApplicationWizardCore/ContentView.swift
@@ -31,7 +31,7 @@ public struct ContentView: View {
         } detail: {
             if let detailStore = store.scope(state: \.jobDetail, action: \.jobDetail) {
                 JobDetailView(store: detailStore)
-                    .navigationSplitViewColumnWidth(min: 300, ideal: 450)
+                    .modifier(detailColumnWidth(aiPanelOpen: store.jobDetail?.aiPanelOpen ?? false))
                     .id(store.selectedJobID)
             } else {
                 ContentUnavailableView(
@@ -91,6 +91,10 @@ public struct ContentView: View {
         } message: {
             Text(store.saveError ?? "")
         }
+    }
+
+    private func detailColumnWidth(aiPanelOpen: Bool) -> DetailColumnWidth {
+        DetailColumnWidth(aiPanelOpen: aiPanelOpen)
     }
 
     var toolbar: some View {
@@ -256,6 +260,23 @@ struct FeatureRow: View {
                 Text(title).fontWeight(.semibold)
                 Text(desc).font(.caption).foregroundColor(.secondary)
             }
+        }
+    }
+}
+
+// MARK: - Detail Column Width
+
+/// Adjusts the detail column min/ideal/max based on whether the AI panel is open.
+/// When the AI panel is closed, a `max` is set so NavigationSplitView reclaims the
+/// extra width and gives it back to the content (job list) column.
+private struct DetailColumnWidth: ViewModifier {
+    let aiPanelOpen: Bool
+
+    func body(content: Content) -> some View {
+        if aiPanelOpen {
+            content.navigationSplitViewColumnWidth(min: 500, ideal: 700)
+        } else {
+            content.navigationSplitViewColumnWidth(min: 460, ideal: 450, max: 600)
         }
     }
 }

--- a/Sources/JobApplicationWizardCore/JobDetailView.swift
+++ b/Sources/JobApplicationWizardCore/JobDetailView.swift
@@ -18,10 +18,11 @@ public struct JobDetailView: View {
             Divider()
             HStack(spacing: 0) {
                 tabContent
+                    .frame(minWidth: 460)
                 if store.aiPanelOpen {
                     Divider()
                     AISidePanel(store: store)
-                        .frame(minWidth: 280, idealWidth: 340, maxWidth: 500)
+                        .frame(minWidth: 360, idealWidth: 360, maxWidth: 500)
                 }
             }
         }
@@ -930,6 +931,7 @@ struct AISidePanel: View {
                     Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.orange).font(.footnote)
                     Text("No job description saved; AI responses will be generic. Paste the JD in the Description tab.")
                         .font(.caption).foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 .padding(8)
                 .background(Color.orange.opacity(0.08))
@@ -939,6 +941,7 @@ struct AISidePanel: View {
                     Image(systemName: "person.crop.circle.badge.exclamationmark").foregroundColor(.orange).font(.footnote)
                     Text("Set up your profile in the sidebar for personalized advice.")
                         .font(.caption).foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 .padding(8)
                 .background(Color.orange.opacity(0.08))
@@ -1005,6 +1008,7 @@ struct AISidePanel: View {
             if store.acpConnection.aiProvider == .acpAgent, let name = store.acpConnection.connectedAgentName {
                 Text("Connected to \(name)")
                     .font(.subheadline).fontWeight(.medium)
+                    .fixedSize(horizontal: false, vertical: true)
             } else {
                 Text("AI Assistant")
                     .font(.subheadline).fontWeight(.medium)
@@ -1012,6 +1016,7 @@ struct AISidePanel: View {
 
             Text("Ask anything about this application, or try a suggestion below.")
                 .font(.caption).foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 300)
 

--- a/Sources/JobApplicationWizardCore/SidebarView.swift
+++ b/Sources/JobApplicationWizardCore/SidebarView.swift
@@ -48,6 +48,7 @@ public struct SidebarView: View {
                             .background(store.viewMode == mode ? Color.accentColor.opacity(0.15) : Color.clear)
                             .foregroundColor(store.viewMode == mode ? .accentColor : .secondary)
                             .clipShape(RoundedRectangle(cornerRadius: 6))
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                 }

--- a/Tests/JobApplicationWizardTests/AppFeatureTests.swift
+++ b/Tests/JobApplicationWizardTests/AppFeatureTests.swift
@@ -448,6 +448,41 @@ final class AppFeatureTests: XCTestCase {
         }
     }
 
+    // MARK: - ACP Disconnect
+
+    func testDisconnectACPAgentClearsConnectionState() async {
+        var state = AppFeature.State()
+        state.$acpConnection.withLock {
+            $0.isConnected = true
+            $0.connectedAgentName = "test-agent"
+        }
+
+        var disconnectCalled = false
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.acpClient = ACPClient(
+                connect: { _ in "" },
+                disconnect: { disconnectCalled = true },
+                sendPrompt: { _, _ in ("", .zero) },
+                onUnexpectedDisconnect: { AsyncStream { $0.finish() } }
+            )
+        }
+
+        store.exhaustivity = .off
+
+        await store.send(.disconnectACPAgent)
+
+        await store.receive(\.acpDisconnected) {
+            $0.$acpConnection.withLock {
+                $0.isConnected = false
+                $0.connectedAgentName = nil
+            }
+        }
+
+        XCTAssertTrue(disconnectCalled, "acpClient.disconnect() should be called")
+    }
+
     func testDismissSaveError() async {
         var state = AppFeature.State()
         state.saveError = "Some error"


### PR DESCRIPTION
## Summary
- Set min widths on tab content (460) and AI panel (360) so neither gets crushed when the window narrows
- Detail column min/max adjusts dynamically: wider when AI panel is open, capped when closed so space returns to the job list column
- Add `fixedSize(horizontal: false, vertical: true)` to AI panel text views so they wrap instead of clip
- Bump window minWidth from 960 to 1200
- Terminate ACP agent subprocess on app quit via `applicationWillTerminate` to prevent zombie `npm exec` processes

## Test plan
- [x] `testDisconnectACPAgentClearsConnectionState` added to AppFeatureTests
- [x] Open a job detail with AI panel open; narrow the window and verify neither side clips
- [x] Close the AI panel and verify the detail column shrinks back
- [x] Quit and relaunch the app; confirm no leftover `npm exec claude-agent-acp` processes in Activity Monitor

Depends on #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)