### PR TITLE
Replace ThinkingBubble with JitterCircle

### DIFF
--- a/Sources/JobApplicationWizardCore/JobDetailView.swift
+++ b/Sources/JobApplicationWizardCore/JobDetailView.swift
@@ -896,6 +896,12 @@ struct InterviewRoundRow: View {
 struct AISidePanel: View {
     @Bindable var store: StoreOf<JobDetailFeature>
     @FocusState private var inputFocused: Bool
+    @State private var thinkingAmplitude: Double = 0.01
+    @State private var showThinking: Bool = false
+
+    private static let minAmplitude: Double = 0.01
+    private static let maxAmplitude: Double = 0.08
+    private static let collapseAmplitude: Double = 0.005
 
     var body: some View {
         VStack(spacing: 0) {
@@ -972,9 +978,9 @@ struct AISidePanel: View {
                                 ChatBubble(message: msg)
                                     .id(msg.id)
                             }
-                            if store.aiIsLoading {
+                            if showThinking {
                                 HStack {
-                                    JitterCircle()
+                                    JitterCircle(amplitudeFrac: thinkingAmplitude)
                                         .frame(width: 40, height: 40)
                                     Spacer()
                                 }
@@ -993,7 +999,17 @@ struct AISidePanel: View {
                 }
                 .onChange(of: store.aiIsLoading) { _, loading in
                     if loading {
+                        // Start small, ease up to full amplitude
+                        thinkingAmplitude = Self.minAmplitude
+                        showThinking = true
                         withAnimation { proxy.scrollTo("bottom") }
+                        withAnimation(.easeIn(duration: 2.0)) {
+                            thinkingAmplitude = Self.maxAmplitude
+                        }
+                    } else {
+                        // Hide immediately so it doesn't linger below the response
+                        showThinking = false
+                        thinkingAmplitude = Self.minAmplitude
                     }
                 }
             }
@@ -1257,7 +1273,7 @@ struct JitterCircle: View {
     @Environment(\.colorScheme) private var colorScheme
 
     // Wave params; amplitude is expressed as fraction of bodyRadius
-    private static let amplitudeFrac: Double = 0.08
+    var amplitudeFrac: Double = 0.08
     private static let frequency: Double = 1.1
     private static let wavelength: Double = 0.46
     private static let waveSpeed: Double = -0.7
@@ -1291,7 +1307,7 @@ struct JitterCircle: View {
                 let cx = size.width * 0.5
                 let cy = size.height * 0.5
                 let bodyRadius = Double(min(size.width, size.height)) * 0.38
-                let amplitude = bodyRadius * Self.amplitudeFrac
+                let amplitude = bodyRadius * amplitudeFrac
                 let totalSegments = 200
                 let numWaves = max(1, (1.0 / Self.wavelength).rounded())
                 let k = 2 * Double.pi * numWaves


### PR DESCRIPTION
## Summary
- Swap the bouncing dots thinking indicator for a small cuttlefish logo (JitterCircle) animation while waiting for AI responses

## Test plan
- [x] Send a message in the AI panel and verify the cuttlefish animation appears while loading
- [x] Verify the animation is left-aligned and properly sized (40x40)

Depends on #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)