### PR TITLE
feat: add column sorting

### DIFF
--- a/Sources/JobApplicationWizardCore/ListView.swift
+++ b/Sources/JobApplicationWizardCore/ListView.swift
@@ -4,28 +4,17 @@ import ComposableArchitecture
 public struct ListView: View {
     let store: StoreOf<AppFeature>
     let onDocumentDrop: (UUID, [URL]) -> Void
-    @State private var sortOrder = SortOrder.dateDesc
+
+    @State
+    private var sortOrder: [KeyPathComparator<JobApplication>] = [KeyPathComparator(\.dateAdded, order: .reverse)]
 
     public init(store: StoreOf<AppFeature>, onDocumentDrop: @escaping (UUID, [URL]) -> Void = { _, _ in }) {
         self.store = store
         self.onDocumentDrop = onDocumentDrop
     }
 
-    enum SortOrder: String, CaseIterable {
-        case dateDesc = "Newest First"
-        case dateAsc  = "Oldest First"
-        case company  = "Company A–Z"
-        case excitement = "Most Excited"
-    }
-
     var sortedJobs: [JobApplication] {
-        let base = store.filteredJobs
-        switch sortOrder {
-        case .dateDesc:   return base.sorted { $0.dateAdded > $1.dateAdded }
-        case .dateAsc:    return base.sorted { $0.dateAdded < $1.dateAdded }
-        case .company:    return base.sorted { $0.company < $1.company }
-        case .excitement: return base.sorted { $0.excitement > $1.excitement }
-        }
+        store.filteredJobs.sorted(using: sortOrder)
     }
 
     var selectionBinding: Binding<UUID?> {
@@ -42,12 +31,6 @@ public struct ListView: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
                 Spacer()
-                Picker("Sort", selection: $sortOrder) {
-                    ForEach(SortOrder.allCases, id: \.self) { Text($0.rawValue).tag($0) }
-                }
-                .pickerStyle(.menu)
-                .font(.caption)
-                .controlSize(.small)
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
@@ -64,8 +47,8 @@ public struct ListView: View {
                         : "Try a different search")
                 )
             } else {
-                Table(sortedJobs, selection: selectionBinding) {
-                    TableColumn("Company / Role") { job in
+                Table(sortedJobs, selection: selectionBinding, sortOrder: $sortOrder) {
+                    TableColumn("Company / Role", value: \.company) { job in
                         VStack(alignment: .leading, spacing: 2) {
                             // Note: cuttleDockable is applied to the whole VStack below
                             HStack(spacing: 5) {
@@ -109,12 +92,12 @@ public struct ListView: View {
                         }
                     }
 
-                    TableColumn("Excitement") { job in
+                    TableColumn("Excitement", value: \.excitement) { job in
                         ExcitementDots(level: job.excitement)
                     }
                     .width(70)
 
-                    TableColumn("Status") { job in
+                    TableColumn("Status", value: \.status) { job in
                         Text(job.status.rawValue)
                             .font(.caption)
                             .padding(.horizontal, 7).padding(.vertical, 2)
@@ -124,19 +107,25 @@ public struct ListView: View {
                     }
                     .width(110)
 
-                    TableColumn("Location") { job in
+                    TableColumn("Location", value: \.location) { job in
                         Text(job.location.isEmpty ? "—" : job.location)
                             .foregroundColor(job.location.isEmpty ? Color.secondary.opacity(0.3) : .secondary)
                             .lineLimit(1)
                     }
                     .width(90)
 
-                    TableColumn("Salary") { job in
+                    TableColumn("Salary", value: \.salary) { job in
                         Text(job.salary.isEmpty ? "—" : job.salary)
                             .foregroundColor(job.salary.isEmpty ? Color.secondary.opacity(0.3) : .green)
                             .lineLimit(1)
                     }
                     .width(160)
+
+                    TableColumn("Date Added", value: \.dateAdded) { job in
+                        Text(job.dateAdded.formatted(date: .abbreviated, time: .omitted))
+                            .foregroundColor(.secondary)
+                    }
+                    .width(90)
                 }
                 .contextMenu(forSelectionType: UUID.self) { ids in
                     if let id = ids.first,

--- a/Sources/JobApplicationWizardCore/Models.swift
+++ b/Sources/JobApplicationWizardCore/Models.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 // MARK: - Job Status
 
-public enum JobStatus: String, Codable, CaseIterable, Identifiable, Equatable {
+public enum JobStatus: String, Codable, CaseIterable, Identifiable, Comparable {
     case wishlist = "Wishlist"
     case applied = "Applied"
     case phoneScreen = "Phone Screen"
@@ -47,6 +47,22 @@ public enum JobStatus: String, Codable, CaseIterable, Identifiable, Equatable {
         case .offer:       return ["Review offer details", "Research market salary", "Negotiate or accept"]
         case .rejected, .withdrawn: return []
         }
+    }
+
+    private var sortIndex: Int {
+        switch self {
+        case .wishlist:    0
+        case .applied:     1
+        case .phoneScreen: 2
+        case .interview:   3
+        case .offer:       4
+        case .rejected:    5
+        case .withdrawn:   6
+        }
+    }
+
+    public static func < (lhs: JobStatus, rhs: JobStatus) -> Bool {
+        lhs.sortIndex < rhs.sortIndex
     }
 }
 


### PR DESCRIPTION
## What
Replace the sort picker in the list view with column header sorting.

## Why
Clicking column headers to sort is the standard macOS table interaction.

## How
- Added `Comparable` conformance to `JobStatus` (order: Wishlist → Withdrawn) so the Status column can be used as a sort key
- Switched `Table` to use SwiftUI's native `sortOrder` binding (`[KeyPathComparator<JobApplication>]`), defaulting to Date Added descending
- Added `value:` key paths to all five existing columns and a new Date Added column
- Removed the `SortOrder` enum and picker

## Testing
- [x] `swift test` passes locally
- [x] Tested in the app: clicked each column header, confirmed sort arrow appears and list re-orders; confirmed clicking again reverses direction; confirmed Date Added column sorts newest/oldest correctly

## Screenshots
<img width="1770" height="1116" alt="Screenshot 2026-03-20 at 3 58 32 PM" src="https://github.com/user-attachments/assets/6d5fe06c-941f-473c-abd0-7d54c1907247" />

https://github.com/user-attachments/assets/36b163fa-29c1-4fdd-b398-73f351968616

## Checklist
- [x] Commits follow `type: description` convention
- [x] I have read CONTRIBUTING.md
