### PR TITLE
Switch sidebar import/export to full JSON backup

### DIFF
--- a/Sources/JobApplicationWizardCore/ContentView.swift
+++ b/Sources/JobApplicationWizardCore/ContentView.swift
@@ -58,17 +58,17 @@ public struct ContentView: View {
                         .buttonStyle(.plain)
                         .help("Settings")
 
-                        Button { store.send(.importCSV) } label: {
+                        Button { store.send(.importAll) } label: {
                             Image(systemName: "square.and.arrow.down").padding(4)
                         }
                         .buttonStyle(.plain)
-                        .help("Import from CSV")
+                        .help("Import from JSON backup")
 
-                        Button { store.send(.exportCSV) } label: {
+                        Button { store.send(.exportAll) } label: {
                             Image(systemName: "square.and.arrow.up").padding(4)
                         }
                         .buttonStyle(.plain)
-                        .help("Export to CSV")
+                        .help("Export full JSON backup")
                     }
                 }
             }
@@ -139,6 +139,22 @@ public struct ContentView: View {
             Button("OK") { store.send(.dismissSaveError) }
         } message: {
             Text(store.saveError ?? "")
+        }
+        .alert(
+            "Replace All Data?",
+            isPresented: Binding(
+                get: { store.showImportAllConfirm },
+                set: { if !$0 { store.send(.cancelImportAll) } }
+            )
+        ) {
+            Button("Replace", role: .destructive) {
+                store.send(.confirmImportAll)
+            }
+            Button("Cancel", role: .cancel) {
+                store.send(.cancelImportAll)
+            }
+        } message: {
+            Text("This will replace all current data with the contents of the backup file. This cannot be undone.")
         }
     }
 

--- a/Sources/JobApplicationWizardCore/SettingsView.swift
+++ b/Sources/JobApplicationWizardCore/SettingsView.swift
@@ -379,22 +379,6 @@ private struct DataSettingsTab: View {
         .formStyle(.grouped)
         .padding(.horizontal, DS.Spacing.lg)
         .padding(.vertical, DS.Spacing.lg)
-        .alert(
-            "Replace All Data?",
-            isPresented: Binding(
-                get: { store.showImportAllConfirm },
-                set: { if !$0 { store.send(.cancelImportAll) } }
-            )
-        ) {
-            Button("Replace", role: .destructive) {
-                store.send(.confirmImportAll)
-            }
-            Button("Cancel", role: .cancel) {
-                store.send(.cancelImportAll)
-            }
-        } message: {
-            Text("This will replace all current data with the contents of the backup file. This cannot be undone.")
-        }
     }
 }
 

--- a/Sources/JobApplicationWizardCore/SidebarView.swift
+++ b/Sources/JobApplicationWizardCore/SidebarView.swift
@@ -102,16 +102,16 @@ public struct SidebarView: View {
                 Spacer()
 
                 Button {
-                    store.send(.importCSV)
+                    store.send(.importAll)
                 } label: {
                     Image(systemName: "square.and.arrow.down")
                         .foregroundColor(DS.Color.textSecondary)
                 }
                 .buttonStyle(.plain)
-                .help("Import from CSV")
+                .help("Import from JSON backup")
 
                 Button {
-                    store.send(.exportCSV)
+                    store.send(.exportAll)
                 } label: {
                     Image(systemName: "square.and.arrow.up")
                         .foregroundColor(DS.Color.textSecondary)


### PR DESCRIPTION
## Summary
- Sidebar and ContentView import/export buttons now use full JSON backup (importAll/exportAll) instead of CSV
- Moves the "Replace All Data?" confirmation alert from SettingsView to ContentView so it appears immediately when triggered from the sidebar
- Settings view retains both CSV and full backup options since they are explicitly labeled

## Test plan
- [x] Click the import button in the sidebar; verify the open dialog filters for JSON and says "backup file"
- [x] Select a JSON backup; verify the "Replace All Data?" confirmation appears on the main window
- [x] Click the export button; verify it saves a JSON file
- [x] Open Settings; verify CSV import/export buttons still work there
- [x] `swift test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)