### PR TITLE
Add privacy policy and terms of service

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy — Job Application Wizard</title>
+    <link rel="stylesheet" href="blogs/blog.css">
+</head>
+<body>
+    <a class="back-link" href="https://github.com/zacspa/JobApplicationWizard">&larr; Back to GitHub</a>
+
+    <h1>Privacy Policy</h1>
+    <p class="post-meta">Last updated: March 26, 2026</p>
+
+    <h2>Overview</h2>
+    <p>
+        Job Application Wizard is an open-source macOS and iOS application that helps you
+        track job applications. Your privacy is important to us; this policy explains what
+        data the app accesses, how it is used, and your choices.
+    </p>
+
+    <h2>Data We Collect</h2>
+    <p>
+        <strong>Job Application Wizard does not collect, transmit, or store any personal data
+        on our servers.</strong> All application data (job listings, notes, contacts, interview
+        details, and tasks) is stored locally on your device.
+    </p>
+
+    <h2>Google Drive Sync (Optional)</h2>
+    <p>
+        If you choose to enable Google Drive sync, the app requests access to the
+        <code>drive.appdata</code> scope, which is limited to a private, app-specific
+        folder in your Google Drive. This folder is not visible in your normal Drive
+        file listing.
+    </p>
+    <p>The app syncs the following structured data to your Google Drive app folder:</p>
+    <ul>
+        <li>Job application metadata: company name, job title, URL, salary, location, status, and excitement rating</li>
+        <li>Contact metadata: name, email, phone</li>
+        <li>Interview round metadata: dates, format, interviewer names</li>
+        <li>Sub-task titles and completion status</li>
+        <li>Custom label names and colors</li>
+        <li>App preferences and settings</li>
+    </ul>
+    <p>The following data is <strong>not</strong> synced and remains only on your device:</p>
+    <ul>
+        <li>AI chat history</li>
+        <li>Full-text job descriptions</li>
+        <li>Full-text cover letters</li>
+        <li>Document raw text and bulk note content</li>
+    </ul>
+    <p>
+        Sync data is stored as JSON files in your Google Drive app-data folder using an
+        append-only event log. You can revoke access at any time through your
+        <a href="https://myaccount.google.com/permissions">Google Account permissions</a>.
+    </p>
+
+    <h2>Authentication</h2>
+    <p>
+        Google sign-in uses OAuth 2.0 with PKCE (Proof Key for Code Exchange).
+        Refresh tokens are stored securely in the iOS Keychain or macOS Keychain.
+        We never see or store your Google password.
+    </p>
+
+    <h2>Third-Party Services</h2>
+    <p>
+        Other than the optional Google Drive integration, Job Application Wizard does not
+        communicate with any third-party services, analytics platforms, or advertising
+        networks.
+    </p>
+
+    <h2>AI Features</h2>
+    <p>
+        The app supports optional AI-assisted features. Any AI provider configuration
+        (API keys, endpoints) is stored locally on your device. Conversations with AI
+        providers are sent directly from your device to the provider you configure;
+        no data passes through our infrastructure.
+    </p>
+
+    <h2>Children's Privacy</h2>
+    <p>
+        Job Application Wizard is not directed at children under 13 and does not knowingly
+        collect data from children.
+    </p>
+
+    <h2>Changes to This Policy</h2>
+    <p>
+        We may update this policy from time to time. Changes will be posted on this page
+        with an updated revision date. Because the app is open source, you can also review
+        changes via the
+        <a href="https://github.com/zacspa/JobApplicationWizard">GitHub repository</a>.
+    </p>
+
+    <h2>Contact</h2>
+    <p>
+        If you have questions about this policy, please open an issue on the
+        <a href="https://github.com/zacspa/JobApplicationWizard/issues">GitHub repository</a>.
+    </p>
+</body>
+</html>

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms of Service — Job Application Wizard</title>
+    <link rel="stylesheet" href="blogs/blog.css">
+</head>
+<body>
+    <a class="back-link" href="https://github.com/zacspa/JobApplicationWizard">&larr; Back to GitHub</a>
+
+    <h1>Terms of Service</h1>
+    <p class="post-meta">Last updated: March 26, 2026</p>
+
+    <h2>Acceptance of Terms</h2>
+    <p>
+        By downloading, installing, or using Job Application Wizard ("the App"), you agree
+        to these Terms of Service. If you do not agree, do not use the App.
+    </p>
+
+    <h2>Description of Service</h2>
+    <p>
+        Job Application Wizard is a free, open-source application for tracking job
+        applications. The source code is available under its license at
+        <a href="https://github.com/zacspa/JobApplicationWizard">github.com/zacspa/JobApplicationWizard</a>.
+    </p>
+
+    <h2>Use of the App</h2>
+    <p>You agree to use the App only for lawful purposes and in accordance with these terms. You are responsible for:</p>
+    <ul>
+        <li>Maintaining the security of your device and any accounts connected to the App</li>
+        <li>All data you enter into the App</li>
+        <li>Any API keys or credentials you configure within the App</li>
+    </ul>
+
+    <h2>Google Drive Integration</h2>
+    <p>
+        The App offers optional sync via Google Drive. By enabling this feature, you
+        authorize the App to read and write data in a private, app-specific folder within
+        your Google Drive account. Your use of Google Drive is also subject to
+        <a href="https://policies.google.com/terms">Google's Terms of Service</a>.
+        You may revoke access at any time through your
+        <a href="https://myaccount.google.com/permissions">Google Account permissions</a>.
+    </p>
+
+    <h2>AI Features</h2>
+    <p>
+        The App supports optional integration with AI providers. You are responsible for
+        complying with the terms of service of any AI provider you configure. The App
+        sends data directly from your device to the provider; we do not intermediate
+        or monitor those communications.
+    </p>
+
+    <h2>Disclaimer of Warranties</h2>
+    <p>
+        The App is provided "as is" and "as available," without warranty of any kind,
+        express or implied, including but not limited to warranties of merchantability,
+        fitness for a particular purpose, or non-infringement. We do not guarantee that
+        the App will be uninterrupted, error-free, or free of harmful components.
+    </p>
+
+    <h2>Limitation of Liability</h2>
+    <p>
+        To the fullest extent permitted by applicable law, the maintainers and contributors
+        of Job Application Wizard shall not be liable for any indirect, incidental, special,
+        consequential, or punitive damages, or any loss of data, opportunities, reputation,
+        or profits, arising out of or related to your use of the App, whether based on
+        warranty, contract, tort, or any other legal theory.
+    </p>
+
+    <h2>Data and Backups</h2>
+    <p>
+        You are solely responsible for maintaining backups of your data. While the App
+        includes sync features, these are provided as a convenience and do not constitute
+        a backup service.
+    </p>
+
+    <h2>Changes to These Terms</h2>
+    <p>
+        We may update these terms from time to time. Changes will be posted on this page
+        with an updated revision date. Continued use of the App after changes are posted
+        constitutes acceptance of the revised terms.
+    </p>
+
+    <h2>Open Source License</h2>
+    <p>
+        The App's source code is governed by its open-source license as specified in the
+        repository. These Terms of Service apply to your use of the compiled application
+        and its services, not to the source code itself.
+    </p>
+
+    <h2>Contact</h2>
+    <p>
+        If you have questions about these terms, please open an issue on the
+        <a href="https://github.com/zacspa/JobApplicationWizard/issues">GitHub repository</a>.
+    </p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `docs/privacy.html` and `docs/terms.html` for GitHub Pages
- Required for Google OAuth consent screen verification
- Covers local-only storage, optional Google Drive sync (appdata scope), AI provider pass-through, no analytics

## Links (once deployed)
- https://zacspa.github.io/JobApplicationWizard/privacy.html
- https://zacspa.github.io/JobApplicationWizard/terms.html

## Test plan
- [ ] Merge and confirm pages render at the GitHub Pages URLs above
- [ ] Submit links in Google OAuth consent screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)