### PR TITLE
Add privacy policy and terms links to About screen

### DIFF
--- a/Sources/JobApplicationWizardCore/SettingsView.swift
+++ b/Sources/JobApplicationWizardCore/SettingsView.swift
@@ -443,6 +443,16 @@ private struct AboutSettingsTab: View {
                     .font(DS.Typography.caption)
                     .foregroundColor(DS.Color.textSecondary)
                     .padding(.top, DS.Spacing.xxs)
+                HStack(spacing: DS.Spacing.md) {
+                    Link("Privacy Policy",
+                         destination: URL(string: "https://zacspa.github.io/JobApplicationWizard/privacy.html")!)
+                    Text("·")
+                        .foregroundColor(DS.Color.textSecondary)
+                    Link("Terms of Service",
+                         destination: URL(string: "https://zacspa.github.io/JobApplicationWizard/terms.html")!)
+                }
+                .font(DS.Typography.caption)
+                .padding(.top, DS.Spacing.sm)
             }
             Spacer()
         }


### PR DESCRIPTION
## Summary
- Adds "Privacy Policy · Terms of Service" links to the About settings tab
- Links point to GitHub Pages: `privacy.html` and `terms.html` (from #32)

## Test plan
- [x] Open Settings > About, verify links appear below the tagline
- [x] Click each link, confirm it opens the correct page in browser
- [x] Merge #32 first so the pages are live

🤖 Generated with [Claude Code](https://claude.com/claude-code)