### PR TITLE
feat: multi-session chat for Cuttle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+      - name: Create stub Secrets.swift
+        run: cp Sources/JobApplicationShared/Secrets.swift.example Sources/JobApplicationShared/Secrets.swift
       - name: Build
         run: swift build
       - name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,10 @@ JobApplicationWizard.app
 JobApplicationWizard.dmg
 .env.local
 .claude/worktrees/
+.agents/
+build/
+commercial/
+default.profraw
+demo_data.json
 iOS/build/
 Sources/JobApplicationShared/Secrets.swift

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,8 @@ let package = Package(
             dependencies: [
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
             ],
-            path: "Sources/JobApplicationShared"
+            path: "Sources/JobApplicationShared",
+            exclude: ["Secrets.swift.example"]
         ),
         .target(
             name: "JobApplicationWizardCore",

--- a/Sources/JobApplicationShared/CuttleContext.swift
+++ b/Sources/JobApplicationShared/CuttleContext.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Determines what data Cuttle scopes its AI conversation to.
-public enum CuttleContext: Equatable, Codable {
+public enum CuttleContext: Equatable, Codable, Sendable {
     case global
     case status(JobStatus)
     case job(UUID)

--- a/Sources/JobApplicationShared/Models.swift
+++ b/Sources/JobApplicationShared/Models.swift
@@ -8,7 +8,7 @@ import UIKit
 
 // MARK: - Job Status
 
-public enum JobStatus: String, Codable, CaseIterable, Identifiable, Comparable {
+public enum JobStatus: String, Codable, CaseIterable, Identifiable, Comparable, Sendable {
     case wishlist = "Wishlist"
     case applied = "Applied"
     case phoneScreen = "Phone Screen"
@@ -73,7 +73,7 @@ public enum JobStatus: String, Codable, CaseIterable, Identifiable, Comparable {
 
 // MARK: - Label
 
-public struct JobLabel: Codable, Identifiable, Hashable, Equatable {
+public struct JobLabel: Codable, Identifiable, Hashable, Equatable, Sendable {
     public var id: UUID = UUID()
     public var name: String
     public var colorHex: String
@@ -104,7 +104,7 @@ public struct JobLabel: Codable, Identifiable, Hashable, Equatable {
 
 // MARK: - Note
 
-public struct Note: Codable, Identifiable, Equatable {
+public struct Note: Codable, Identifiable, Equatable, Sendable {
     public var id: UUID = UUID()
     public var title: String = ""
     public var subtitle: String = ""
@@ -126,7 +126,7 @@ public struct Note: Codable, Identifiable, Equatable {
 
 // MARK: - Contact
 
-public struct Contact: Codable, Identifiable, Equatable {
+public struct Contact: Codable, Identifiable, Equatable, Sendable {
     public var id: UUID = UUID()
     public var name: String = ""
     public var title: String = ""
@@ -148,7 +148,7 @@ public struct Contact: Codable, Identifiable, Equatable {
 
 // MARK: - SubTask
 
-public struct SubTask: Identifiable, Codable, Equatable {
+public struct SubTask: Identifiable, Codable, Equatable, Sendable {
     public var id: UUID = UUID()
     public var title: String
     public var isCompleted: Bool = false
@@ -164,7 +164,7 @@ public struct SubTask: Identifiable, Codable, Equatable {
 
 // MARK: - Interview Round
 
-public struct InterviewRound: Codable, Identifiable, Equatable {
+public struct InterviewRound: Codable, Identifiable, Equatable, Sendable {
     public var id: UUID = UUID()
     public var round: Int
     public var type: String = ""
@@ -190,7 +190,7 @@ public struct InterviewRound: Codable, Identifiable, Equatable {
 
 // MARK: - Job Document
 
-public struct JobDocument: Codable, Identifiable, Equatable {
+public struct JobDocument: Codable, Identifiable, Equatable, Sendable {
     public var id: UUID = UUID()
     public var filename: String
     public var documentType: DocumentType
@@ -220,7 +220,7 @@ public struct JobDocument: Codable, Identifiable, Equatable {
 
 // MARK: - Job Application
 
-public struct JobApplication: Codable, Identifiable, Equatable {
+public struct JobApplication: Codable, Identifiable, Equatable, Sendable {
     public var id: UUID = UUID()
     public var company: String = ""
     public var title: String = ""
@@ -241,7 +241,7 @@ public struct JobApplication: Codable, Identifiable, Equatable {
     public var excitement: Int = 3
     public var hasPDF: Bool = false
     public var pdfPath: String? = nil
-    public var chatHistory: [ChatMessage] = []
+    public var chatSessions: [ChatSession] = []
     public var documents: [JobDocument] = []
     public var tasks: [SubTask] = []
     public var atsProvider: ATSProvider?
@@ -271,12 +271,18 @@ public struct JobApplication: Codable, Identifiable, Equatable {
         case id, company, title, url, status, dateAdded, dateApplied
         case salary, location, jobDescription, noteCards
         case resumeUsed, coverLetter, labels, contacts, interviews
-        case isFavorite, excitement, hasPDF, pdfPath, chatHistory, documents, tasks, atsProvider, updatedAt
+        case isFavorite, excitement, hasPDF, pdfPath, chatSessions, documents, tasks, atsProvider, updatedAt
         case legacyNotes = "notes"
+    }
+
+    /// Decode-only keys for migrating legacy data formats.
+    private enum LegacyCodingKeys: String, CodingKey {
+        case chatHistory
     }
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
+        let legacy = try decoder.container(keyedBy: LegacyCodingKeys.self)
         id           = try c.decodeIfPresent(UUID.self,            forKey: .id)           ?? UUID()
         company      = try c.decodeIfPresent(String.self,          forKey: .company)      ?? ""
         title        = try c.decodeIfPresent(String.self,          forKey: .title)        ?? ""
@@ -296,7 +302,16 @@ public struct JobApplication: Codable, Identifiable, Equatable {
         excitement   = try c.decodeIfPresent(Int.self,             forKey: .excitement)   ?? 3
         hasPDF       = try c.decodeIfPresent(Bool.self,            forKey: .hasPDF)       ?? false
         pdfPath      = try c.decodeIfPresent(String.self,          forKey: .pdfPath)
-        chatHistory  = try c.decodeIfPresent([ChatMessage].self,   forKey: .chatHistory)  ?? []
+        if let sessions = try c.decodeIfPresent([ChatSession].self, forKey: .chatSessions) {
+            chatSessions = sessions
+        } else if let old = try legacy.decodeIfPresent([ChatMessage].self, forKey: .chatHistory), !old.isEmpty {
+            chatSessions = [ChatSession(
+                providerType: .claudeAPI, messages: old,
+                createdAt: old.first?.timestamp ?? Date(), lastMessageAt: old.last?.timestamp ?? Date()
+            )]
+        } else {
+            chatSessions = []
+        }
         documents    = try c.decodeIfPresent([JobDocument].self,  forKey: .documents)    ?? []
         tasks        = try c.decodeIfPresent([SubTask].self,        forKey: .tasks)        ?? []
         atsProvider  = try c.decodeIfPresent(ATSProvider.self,     forKey: .atsProvider)
@@ -333,8 +348,8 @@ public struct JobApplication: Codable, Identifiable, Equatable {
         try c.encode(excitement,     forKey: .excitement)
         try c.encode(hasPDF,         forKey: .hasPDF)
         try c.encodeIfPresent(pdfPath, forKey: .pdfPath)
-        if !chatHistory.isEmpty {
-            try c.encode(chatHistory, forKey: .chatHistory)
+        if !chatSessions.isEmpty {
+            try c.encode(chatSessions, forKey: .chatSessions)
         }
         if !documents.isEmpty {
             try c.encode(documents, forKey: .documents)
@@ -347,7 +362,7 @@ public struct JobApplication: Codable, Identifiable, Equatable {
 
 // MARK: - Work Preference
 
-public enum WorkPreference: String, Codable, CaseIterable, Equatable {
+public enum WorkPreference: String, Codable, CaseIterable, Equatable, Sendable {
     case remote   = "Remote"
     case hybrid   = "Hybrid"
     case onSite   = "On-Site"
@@ -356,7 +371,7 @@ public enum WorkPreference: String, Codable, CaseIterable, Equatable {
 
 // MARK: - Company Profile
 
-public struct CompanyProfile: Codable, Identifiable, Equatable {
+public struct CompanyProfile: Codable, Identifiable, Equatable, Sendable {
     public var id: UUID = UUID()
     public var name: String
     public var website: String = ""
@@ -386,7 +401,7 @@ public struct CompanyProfile: Codable, Identifiable, Equatable {
 
 // MARK: - User Profile
 
-public struct UserProfile: Codable, Equatable {
+public struct UserProfile: Codable, Equatable, Sendable {
     public var name: String = ""
     public var currentTitle: String = ""
     public var location: String = ""
@@ -437,15 +452,15 @@ public struct ACPConnectionState: Equatable, Sendable {
 
 // MARK: - App Settings
 
-public struct AppSettings: Codable, Equatable {
+public struct AppSettings: Codable, Equatable, Sendable {
     // API key is stored in the system Keychain, not here.
     public var userProfile: UserProfile = UserProfile()
     public var defaultViewMode: ViewMode = .kanban
     public var aiProvider: AIProvider = .acpAgent
     public var selectedACPAgentId: String? = nil
     public var cuttleContext: CuttleContext? = nil
-    public var globalChatHistory: [ChatMessage] = []
-    public var statusChatHistories: [String: [ChatMessage]] = [:]
+    public var globalChatSessions: [ChatSession] = []
+    public var statusChatSessions: [String: [ChatSession]] = [:]
     public var agentActionMode: AgentActionMode = .applyImmediately
     public var autoProcessDocuments: Bool = false
     public var hasCuttleOnboardingCompleted: Bool = false
@@ -453,21 +468,48 @@ public struct AppSettings: Codable, Equatable {
 
     private enum CodingKeys: String, CodingKey {
         case userProfile, defaultViewMode, aiProvider, selectedACPAgentId
-        case cuttleContext, globalChatHistory, statusChatHistories
+        case cuttleContext, globalChatSessions, statusChatSessions
         case agentActionMode, autoProcessDocuments, hasCuttleOnboardingCompleted, companyProfiles
+    }
+
+    /// Legacy keys used only for migration decoding.
+    private enum LegacyCodingKeys: String, CodingKey {
+        case globalChatHistory, statusChatHistories
     }
 
     public init() {}
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
+        let legacy = try decoder.container(keyedBy: LegacyCodingKeys.self)
         userProfile          = try c.decodeIfPresent(UserProfile.self,            forKey: .userProfile)          ?? UserProfile()
         defaultViewMode      = try c.decodeIfPresent(ViewMode.self,               forKey: .defaultViewMode)      ?? .kanban
         aiProvider           = try c.decodeIfPresent(AIProvider.self,             forKey: .aiProvider)           ?? .acpAgent
         selectedACPAgentId   = try c.decodeIfPresent(String.self,                 forKey: .selectedACPAgentId)
         cuttleContext        = try c.decodeIfPresent(CuttleContext.self,          forKey: .cuttleContext)
-        globalChatHistory    = try c.decodeIfPresent([ChatMessage].self,          forKey: .globalChatHistory)    ?? []
-        statusChatHistories  = try c.decodeIfPresent([String: [ChatMessage]].self, forKey: .statusChatHistories) ?? [:]
+        if let sessions = try c.decodeIfPresent([ChatSession].self, forKey: .globalChatSessions) {
+            globalChatSessions = sessions
+        } else if let old = try legacy.decodeIfPresent([ChatMessage].self, forKey: .globalChatHistory), !old.isEmpty {
+            globalChatSessions = [ChatSession(
+                providerType: .claudeAPI, messages: old,
+                createdAt: old.first?.timestamp ?? Date(), lastMessageAt: old.last?.timestamp ?? Date()
+            )]
+        } else {
+            globalChatSessions = []
+        }
+        if let sessions = try c.decodeIfPresent([String: [ChatSession]].self, forKey: .statusChatSessions) {
+            statusChatSessions = sessions
+        } else if let old = try legacy.decodeIfPresent([String: [ChatMessage]].self, forKey: .statusChatHistories) {
+            statusChatSessions = old.compactMapValues { msgs -> [ChatSession]? in
+                guard !msgs.isEmpty else { return nil }
+                return [ChatSession(
+                    providerType: .claudeAPI, messages: msgs,
+                    createdAt: msgs.first?.timestamp ?? Date(), lastMessageAt: msgs.last?.timestamp ?? Date()
+                )]
+            }
+        } else {
+            statusChatSessions = [:]
+        }
         agentActionMode      = try c.decodeIfPresent(AgentActionMode.self,        forKey: .agentActionMode)      ?? .applyImmediately
         autoProcessDocuments = try c.decodeIfPresent(Bool.self,                    forKey: .autoProcessDocuments) ?? false
         hasCuttleOnboardingCompleted = try c.decodeIfPresent(Bool.self,            forKey: .hasCuttleOnboardingCompleted) ?? false
@@ -477,7 +519,7 @@ public struct AppSettings: Codable, Equatable {
 
 // MARK: - App Data Export
 
-public struct AppDataExport: Codable, Equatable {
+public struct AppDataExport: Codable, Equatable, Sendable {
     public static let currentVersion = 1
     public var version: Int = Self.currentVersion
     public var exportedAt: Date = Date()
@@ -492,7 +534,7 @@ public struct AppDataExport: Codable, Equatable {
 
 // MARK: - AI Action
 
-public enum AIAction: String, CaseIterable, Equatable {
+public enum AIAction: String, CaseIterable, Equatable, Sendable {
     case chat = "Chat"
     case tailorResume = "Tailor Resume"
     case coverLetter = "Cover Letter"
@@ -502,13 +544,13 @@ public enum AIAction: String, CaseIterable, Equatable {
 
 // MARK: - Chat Message
 
-public struct ChatMessage: Codable, Identifiable, Equatable {
+public struct ChatMessage: Codable, Identifiable, Equatable, Sendable {
     public var id: UUID = UUID()
     public var role: Role
     public var content: String
     public var timestamp: Date = Date()
 
-    public enum Role: String, Codable, Equatable {
+    public enum Role: String, Codable, Equatable, Sendable {
         case user = "user"
         case assistant = "assistant"
     }
@@ -518,6 +560,58 @@ public struct ChatMessage: Codable, Identifiable, Equatable {
         self.role = role
         self.content = content
         self.timestamp = timestamp
+    }
+}
+
+// MARK: - Chat Session
+
+public struct ChatSession: Codable, Identifiable, Equatable, Sendable {
+    public var id: UUID
+    public var providerType: AIProvider
+    /// Optional agent display name (for ACP agents); nil for Claude API.
+    public var agentName: String? = nil
+    public var messages: [ChatMessage]
+    public var createdAt: Date
+    public var lastMessageAt: Date
+    /// LLM-generated title, nil until generated.
+    public var generatedTitle: String? = nil
+
+    /// Provider display name, derived from providerType and agentName.
+    public var providerName: String {
+        switch providerType {
+        case .acpAgent: return agentName ?? "ACP Agent"
+        case .claudeAPI: return "Claude API"
+        }
+    }
+
+    /// Display title: LLM-generated if available, otherwise first few words of the first user message.
+    public var displayTitle: String {
+        if let generatedTitle, !generatedTitle.isEmpty { return generatedTitle }
+        let first = messages.first(where: { $0.role == .user })?.content ?? ""
+        let words = first.split(separator: " ").prefix(4).joined(separator: " ")
+        return words.isEmpty ? "New Session" : words
+    }
+
+    /// Longer preview for the subtitle line.
+    public var preview: String {
+        let first = messages.first(where: { $0.role == .user })?.content ?? ""
+        return String(first.prefix(60))
+    }
+
+    public init(
+        id: UUID = UUID(),
+        providerType: AIProvider,
+        agentName: String? = nil,
+        messages: [ChatMessage] = [],
+        createdAt: Date = Date(),
+        lastMessageAt: Date = Date()
+    ) {
+        self.id = id
+        self.providerType = providerType
+        self.agentName = agentName
+        self.messages = messages
+        self.createdAt = createdAt
+        self.lastMessageAt = lastMessageAt
     }
 }
 

--- a/Sources/JobApplicationShared/ViewMode.swift
+++ b/Sources/JobApplicationShared/ViewMode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum ViewMode: String, Codable, CaseIterable, Equatable {
+public enum ViewMode: String, Codable, CaseIterable, Equatable, Sendable {
     case kanban = "Kanban"
     case list = "List"
 

--- a/Sources/JobApplicationWizardCore/Components/ChatComponents.swift
+++ b/Sources/JobApplicationWizardCore/Components/ChatComponents.swift
@@ -126,6 +126,44 @@ public struct FlowLayout: Layout {
     }
 }
 
+// MARK: - Session Row
+
+public struct SessionRow: View {
+    public let session: ChatSession
+    public let isActive: Bool
+    public let onSelect: () -> Void
+    public let onDelete: () -> Void
+
+    public init(session: ChatSession, isActive: Bool, onSelect: @escaping () -> Void, onDelete: @escaping () -> Void) {
+        self.session = session
+        self.isActive = isActive
+        self.onSelect = onSelect
+        self.onDelete = onDelete
+    }
+
+    public var body: some View {
+        Button(action: onSelect) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(session.displayTitle)
+                    .font(DS.Typography.caption2).fontWeight(.medium)
+                    .lineLimit(1)
+                Text(session.lastMessageAt, style: .relative)
+                    .font(DS.Typography.micro)
+                    .foregroundColor(DS.Color.textSecondary)
+            }
+            .padding(.horizontal, DS.Spacing.sm)
+            .padding(.vertical, DS.Spacing.xs)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isActive ? Color.accentColor.opacity(0.15) : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: DS.Radius.small))
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button("Delete", role: .destructive, action: onDelete)
+        }
+    }
+}
+
 // MARK: - Chat Input Bar
 
 public struct ChatInputBar: View {
@@ -214,7 +252,7 @@ public struct ChatInputBar: View {
             }
             .onAppear { inputFocused = true }
             HStack {
-                Button("Clear conversation", action: onClear)
+                Button("New session", action: onClear)
                     .buttonStyle(GhostButtonStyle()).font(DS.Typography.footnote)
                     .disabled(!hasMessages)
                 Spacer()

--- a/Sources/JobApplicationWizardCore/CuttleView.swift
+++ b/Sources/JobApplicationWizardCore/CuttleView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import ComposableArchitecture
+import JobApplicationShared
 
 // MARK: - CuttleView
 
@@ -35,17 +36,6 @@ public struct CuttleView: View {
                     .contentShape(Rectangle())
                     .onTapGesture {
                         store.send(.collapse)
-                    }
-                    .accessibilityHidden(true)
-            }
-
-            // Click-outside-to-dismiss overlay for context transition CTA.
-            // Defaults to "Start Fresh" when clicking outside.
-            if store.showContextTransitionAlert {
-                Color.clear
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        store.send(.cancelContextTransition)
                     }
                     .accessibilityHidden(true)
             }
@@ -95,16 +85,10 @@ public struct CuttleView: View {
                         }
                 )
 
-            // Inline context transition CTA
-            if store.showContextTransitionAlert {
-                contextTransitionCTA
-                    .position(contextCTAPosition)
-                    .transition(.scale(scale: 0.9).combined(with: .opacity))
-            }
         }
         .animation(.spring(response: 0.35, dampingFraction: 0.7), value: store.position)
         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: store.isExpanded)
-        .animation(.spring(response: 0.25, dampingFraction: 0.85), value: store.showContextTransitionAlert)
+        .animation(.spring(response: 0.25, dampingFraction: 0.85), value: store.isSessionSidebarVisible)
         .onChange(of: store.isLoading) { _, loading in
             if loading {
                 thinkingAmplitude = 0.01
@@ -200,6 +184,29 @@ public struct CuttleView: View {
     // MARK: - Expanded Chat View
 
     private var expandedView: some View {
+        HStack(spacing: 0) {
+            if store.isSessionSidebarVisible {
+                sessionSidebar
+                    .frame(width: 160)
+                    .transition(.move(edge: .leading).combined(with: .opacity))
+
+                Divider()
+            }
+
+            chatColumn
+        }
+        .frame(width: chatSize.width, height: chatSize.height)
+        .glassSurface(radius: DS.Radius.xxl, shadow: DS.Shadow.noShadow)
+        .clipShape(RoundedRectangle(cornerRadius: DS.Radius.xxl))
+        .dsShadow(DS.Shadow.floating)
+        .overlay(alignment: .bottomTrailing) {
+            resizeHandle
+        }
+    }
+
+    // MARK: - Chat Column
+
+    private var chatColumn: some View {
         VStack(spacing: 0) {
             // Header with provider info
             headerBar
@@ -253,6 +260,26 @@ public struct CuttleView: View {
                             withAnimation { proxy.scrollTo("bottom") }
                         }
                     }
+                    .onChange(of: store.isExpanded) { _, expanded in
+                        if expanded {
+                            Task { @MainActor in
+                                try? await Task.sleep(nanoseconds: 100_000_000)
+                                withAnimation { proxy.scrollTo("bottom") }
+                            }
+                        }
+                    }
+                    .onAppear {
+                        Task { @MainActor in
+                            try? await Task.sleep(nanoseconds: 150_000_000)
+                            proxy.scrollTo("bottom")
+                        }
+                    }
+                    .onChange(of: store.activeSessionID) { _, _ in
+                        Task { @MainActor in
+                            try? await Task.sleep(nanoseconds: 100_000_000)
+                            withAnimation { proxy.scrollTo("bottom") }
+                        }
+                    }
                 }
 
                 Divider()
@@ -269,12 +296,56 @@ public struct CuttleView: View {
                 )
             }
         }
-        .frame(width: chatSize.width, height: chatSize.height)
-        .glassSurface(radius: DS.Radius.xxl, shadow: DS.Shadow.noShadow)
-        .clipShape(RoundedRectangle(cornerRadius: DS.Radius.xxl))
-        .dsShadow(DS.Shadow.floating)
-        .overlay(alignment: .bottomTrailing) {
-            resizeHandle
+    }
+
+    // MARK: - Session Sidebar
+
+    private var sessionSidebar: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Sessions")
+                    .font(DS.Typography.caption).fontWeight(.semibold)
+                Spacer()
+                Button { store.send(.clearChat) } label: {
+                    Image(systemName: "plus")
+                        .font(DS.Typography.caption)
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(DS.Color.textSecondary)
+                .help("New session")
+            }
+            .padding(.horizontal, DS.Spacing.sm)
+            .padding(.vertical, DS.Spacing.sm)
+
+            Divider()
+
+            ScrollView {
+                let sessions = Array(currentContextSessions.reversed())
+                LazyVStack(spacing: 2) {
+                    ForEach(sessions) { session in
+                        SessionRow(
+                            session: session,
+                            isActive: session.id == store.activeSessionID,
+                            onSelect: { store.send(.selectSession(session.id)) },
+                            onDelete: { store.send(.deleteSession(session.id)) }
+                        )
+                    }
+                }
+                .padding(.vertical, DS.Spacing.xs)
+                .padding(.horizontal, DS.Spacing.xxs)
+            }
+        }
+        .background(DS.Color.controlBackground.opacity(0.5))
+    }
+
+    private var currentContextSessions: [ChatSession] {
+        switch store.currentContext {
+        case .global:
+            return store.globalChatSessions
+        case .status(let status):
+            return store.statusChatSessions[status.rawValue] ?? []
+        case .job:
+            return store.activeJobSessions
         }
     }
 
@@ -318,6 +389,16 @@ public struct CuttleView: View {
 
     private var headerBar: some View {
         HStack(spacing: DS.Spacing.xs) {
+            Button {
+                store.send(.toggleSessionSidebar)
+            } label: {
+                Image(systemName: "sidebar.left")
+                    .font(DS.Typography.caption)
+            }
+            .buttonStyle(.plain)
+            .foregroundColor(store.isSessionSidebarVisible ? .accentColor : DS.Color.textSecondary)
+            .help("Toggle sessions sidebar")
+
             Text(store.currentContext.displayLabel(jobs: store.jobs))
                 .font(DS.Typography.caption).fontWeight(.semibold)
                 .lineLimit(1)
@@ -337,7 +418,7 @@ public struct CuttleView: View {
             }
         }
         .padding(.horizontal, DS.Spacing.lg).padding(.vertical, DS.Spacing.sm)
-        .background(DS.Color.controlBackground.opacity(0.5))
+        .background { DS.Color.controlBackground.opacity(0.5) }
         .contentShape(Rectangle())
         .gesture(
             DragGesture(coordinateSpace: .named("cuttle-window"))
@@ -426,63 +507,6 @@ public struct CuttleView: View {
                 "Prep me for interviews",
             ]
         }
-    }
-
-    // MARK: - Context Transition CTA
-
-    private var contextTransitionCTA: some View {
-        VStack(spacing: DS.Spacing.pillH) {
-            Text("Switch to \(store.alertPendingContext?.displayLabel(jobs: store.jobs) ?? "new context")?")
-                .font(DS.Typography.subheadlineSemibold)
-                .lineLimit(2)
-                .multilineTextAlignment(.center)
-
-            HStack(spacing: DS.Spacing.md) {
-                Button("Carry Chat") {
-                    store.send(.contextTransitionConfirmed(carry: true))
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-
-                Button("Start Fresh") {
-                    store.send(.contextTransitionConfirmed(carry: false))
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-        }
-        .padding(.horizontal, DS.Spacing.xl)
-        .padding(.vertical, DS.Spacing.lg)
-        .frame(width: 260)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: DS.Radius.xl))
-        .overlay(
-            RoundedRectangle(cornerRadius: DS.Radius.xl)
-                .stroke(DS.Color.borderSubtle, lineWidth: 1)
-        )
-        .shadow(color: .black.opacity(DS.Color.Opacity.tint), radius: 8, y: 2)
-    }
-
-    /// Position the CTA card below the blob, clamped to window bounds.
-    private var contextCTAPosition: CGPoint {
-        let blob = store.position
-        let windowSize = store.windowSize
-        let ctaWidth: CGFloat = 260
-        let ctaHeight: CGFloat = 80
-        let gap: CGFloat = 8
-
-        var x = blob.x
-        var y = blob.y + Self.collapsedSize / 2 + gap + ctaHeight / 2
-
-        // Clamp horizontal
-        let margin: CGFloat = 8
-        x = max(margin + ctaWidth / 2, min(x, windowSize.width - margin - ctaWidth / 2))
-
-        // If it would go below the window, show above the blob instead
-        if y + ctaHeight / 2 > windowSize.height - margin {
-            y = blob.y - Self.collapsedSize / 2 - gap - ctaHeight / 2
-        }
-
-        return CGPoint(x: x, y: y)
     }
 
     // MARK: - Not Ready View

--- a/Sources/JobApplicationWizardCore/Features/App/AppFeature.swift
+++ b/Sources/JobApplicationWizardCore/Features/App/AppFeature.swift
@@ -9,6 +9,7 @@ public struct AppFeature {
 
     /// Stable ID for the demo job inserted during onboarding so the board isn't empty.
     static let onboardingDemoJobID = UUID(uuidString: "00000000-0000-0000-0000-DE0000000001")!
+    static let onboardingDemoSessionID = UUID(uuidString: "00000000-0000-0000-0000-DE0000000002")!
 
     @ObservableState
     public struct State: Equatable {
@@ -224,8 +225,8 @@ public struct AppFeature {
                 return .merge(
                     .send(.cuttle(.restoreFromSettings(
                         context,
-                        settings.globalChatHistory,
-                        settings.statusChatHistories
+                        settings.globalChatSessions,
+                        settings.statusChatSessions
                     ))),
                     settings.aiProvider == .acpAgent ? .send(.fetchACPRegistry) : .none,
                     shouldStartOnboarding ? .send(.cuttleOnboarding(.start)) : .none
@@ -304,7 +305,8 @@ public struct AppFeature {
                 state.cuttle.jobs = Array(state.jobs)
                 if case .job(let cuttleJobId) = state.cuttle.currentContext, cuttleJobId == id {
                     state.cuttle.currentContext = .global
-                    state.cuttle.chatMessages = state.cuttle.globalChatHistory
+                    state.cuttle.chatMessages = state.cuttle.globalChatSessions.last?.messages ?? []
+                    state.cuttle.activeSessionID = state.cuttle.globalChatSessions.last?.id
                     state.cuttle.tokenUsage = .zero
                     state.cuttle.error = nil
                     state.cuttle.acpSentSystemPrompt = false
@@ -409,7 +411,8 @@ public struct AppFeature {
                 state.cuttle.jobs = Array(state.jobs)
                 if case .job(let cuttleJobId) = state.cuttle.currentContext, cuttleJobId == id {
                     state.cuttle.currentContext = .global
-                    state.cuttle.chatMessages = state.cuttle.globalChatHistory
+                    state.cuttle.chatMessages = state.cuttle.globalChatSessions.last?.messages ?? []
+                    state.cuttle.activeSessionID = state.cuttle.globalChatSessions.last?.id
                     state.cuttle.tokenUsage = .zero
                     state.cuttle.error = nil
                     state.cuttle.acpSentSystemPrompt = false
@@ -433,8 +436,8 @@ public struct AppFeature {
 
             // MARK: - Cuttle
 
-            case .cuttle(.delegate(.jobChatUpdated(let jobId, let messages))):
-                state.jobs[id: jobId]?.chatHistory = messages
+            case .cuttle(.delegate(.jobChatUpdated(let jobId, let sessions))):
+                state.jobs[id: jobId]?.chatSessions = sessions
                 state.cuttle.jobs = Array(state.jobs)
                 return .merge(
                     saveJobs(state.jobs),
@@ -471,10 +474,13 @@ public struct AppFeature {
                     return .none
                 }
 
-            case .cuttle(.aiResponseReceived),
+            case .cuttle(.sendMessage),
+                 .cuttle(.aiResponseReceived),
                  .cuttle(.clearChat),
-                 .cuttle(.contextTransitionConfirmed),
-                 .cuttle(.switchContext):
+                 .cuttle(.switchContext),
+                 .cuttle(.sessionTitleGenerated),
+                 .cuttle(.selectSession),
+                 .cuttle(.deleteSession):
                 return .send(.saveCuttleState)
 
             case .cuttle:
@@ -482,8 +488,8 @@ public struct AppFeature {
 
             case .saveCuttleState:
                 state.settings.cuttleContext = state.cuttle.currentContext
-                state.settings.globalChatHistory = state.cuttle.globalChatHistory
-                state.settings.statusChatHistories = state.cuttle.statusChatHistories
+                state.settings.globalChatSessions = state.cuttle.globalChatSessions
+                state.settings.statusChatSessions = state.cuttle.statusChatSessions
                 return saveSettings(state.settings)
 
             // MARK: - History
@@ -1095,13 +1101,15 @@ public struct AppFeature {
             case .cuttleOnboarding(.delegate(.completed)),
                  .cuttleOnboarding(.delegate(.dismissed)):
                 state.settings.hasCuttleOnboardingCompleted = true
-                // Remove the demo job if it was inserted for the tour
+                // Remove demo content inserted for the tour
                 if state.jobs[id: Self.onboardingDemoJobID] != nil {
                     state.jobs.remove(id: Self.onboardingDemoJobID)
                     state.cuttle.jobs = Array(state.jobs)
                 }
+                state.cuttle.globalChatSessions.removeAll { $0.id == Self.onboardingDemoSessionID }
+                state.cuttle.isSessionSidebarVisible = false
                 return .merge(
-                    saveSettings(state.settings),
+                    .send(.saveCuttleState),
                     saveJobs(state.jobs)
                 )
 
@@ -1111,6 +1119,30 @@ public struct AppFeature {
 
             case .cuttleOnboarding(.delegate(.collapseCuttle)):
                 state.cuttle.isExpanded = false
+                return .none
+
+            case .cuttleOnboarding(.delegate(.showSessionSidebar)):
+                state.cuttle.isSessionSidebarVisible = true
+                // Insert a fake session so the sidebar isn't empty during onboarding
+                if state.cuttle.globalChatSessions.isEmpty {
+                    let fakeSession = ChatSession(
+                        id: Self.onboardingDemoSessionID,
+                        providerType: .acpAgent,
+                        agentName: "AI Assistant",
+                        messages: [
+                            ChatMessage(role: .user, content: "Which roles should I prioritize?"),
+                            ChatMessage(role: .assistant, content: "Based on your profile, I'd focus on the roles where you match 3+ of the listed requirements. Want me to compare your top prospects?"),
+                        ],
+                        createdAt: Date().addingTimeInterval(-3600),
+                        lastMessageAt: Date().addingTimeInterval(-3500)
+                    )
+                    state.cuttle.globalChatSessions.append(fakeSession)
+                }
+                return .none
+
+            case .cuttleOnboarding(.delegate(.hideSessionSidebar)):
+                state.cuttle.isSessionSidebarVisible = false
+                state.cuttle.globalChatSessions.removeAll { $0.id == Self.onboardingDemoSessionID }
                 return .none
 
             case .cuttleOnboarding(.delegate(.agentConnected(let agentId, let agentName))):

--- a/Sources/JobApplicationWizardCore/Features/Cuttle/CuttleFeature.swift
+++ b/Sources/JobApplicationWizardCore/Features/Cuttle/CuttleFeature.swift
@@ -4,7 +4,7 @@ import Foundation
 
 @Reducer
 public struct CuttleFeature {
-    private enum CancelID { case aiRequest }
+    private enum CancelID { case aiRequest, titleGeneration }
 
     /// Maximum messages retained per context when saving chat history.
     private static let maxHistoryMessages = 100
@@ -15,9 +15,6 @@ public struct CuttleFeature {
         public var currentContext: CuttleContext = .global
         /// Non-nil only while actively dragging over a drop zone; drives the glow overlay.
         public var pendingContext: CuttleContext? = nil
-        /// Saved pending context for the carry/fresh alert (persists after drag ends).
-        public var alertPendingContext: CuttleContext? = nil
-        public var showContextTransitionAlert: Bool = false
 
         // Position & drag
         public var position: CGPoint = CGPoint(x: 60, y: 120)
@@ -38,6 +35,12 @@ public struct CuttleFeature {
         // Mood
         public var mood: CuttleMood = .idle
 
+        /// Context and session that own the current in-flight AI request.
+        /// When the user docks elsewhere mid-request, these let us write
+        /// the response back to the originating session's history.
+        public var inFlightContext: CuttleContext? = nil
+        public var inFlightSessionID: UUID? = nil
+
         // Drop zones reported by views
         public var dropZones: [DropZone] = []
 
@@ -49,9 +52,15 @@ public struct CuttleFeature {
         public var userProfile: UserProfile = UserProfile()
         public var jobs: [JobApplication] = []
 
-        // Persisted chat histories (global and per-status)
-        public var globalChatHistory: [ChatMessage] = []
-        public var statusChatHistories: [String: [ChatMessage]] = [:]
+        // Session management
+        public var activeSessionID: UUID? = nil
+        public var isSessionSidebarVisible: Bool = false
+
+        // Persisted chat sessions (global and per-status)
+        public var globalChatSessions: [ChatSession] = []
+        public var statusChatSessions: [String: [ChatSession]] = [:]
+        /// Local buffer for the current job's sessions (synced via delegate on save).
+        public var activeJobSessions: [ChatSession] = []
 
         // ACP connection (shared)
         @SharedReader(.inMemory("acpConnection")) public var acpConnection = ACPConnectionState()
@@ -79,25 +88,28 @@ public struct CuttleFeature {
         // Expand/collapse
         case toggleExpanded
         case collapse
-        // Context transition
-        case contextTransitionConfirmed(carry: Bool)
-        case cancelContextTransition
+        // Context
         case switchContext(CuttleContext)
         // Chat
         case sendMessage(String)
         case aiResponseReceived(Result<(String, AITokenUsage, AgentActionBlock?), Error>)
         case clearChat
         case applySuggestion(String)
+        // Sessions
+        case toggleSessionSidebar
+        case selectSession(UUID)
+        case deleteSession(UUID)
+        case sessionTitleGenerated(UUID, String)
         // Lifecycle
-        case restoreFromSettings(CuttleContext, [ChatMessage], [String: [ChatMessage]])
+        case restoreFromSettings(CuttleContext, [ChatSession], [String: [ChatSession]])
         case positionAtDropZone
         // Delegate (parent actions)
         case delegate(Delegate)
 
         @CasePathable
         public enum Delegate: Equatable {
-            /// Job-context chat was updated; parent should persist to the job model.
-            case jobChatUpdated(UUID, [ChatMessage])
+            /// Job-context sessions were updated; parent should persist to the job model.
+            case jobChatUpdated(UUID, [ChatSession])
             /// Cuttle docked on a job; parent should select it in the detail pane.
             case contextChanged(CuttleContext)
             /// Agent proposed actions to apply to a job.
@@ -107,6 +119,7 @@ public struct CuttleFeature {
 
     @Dependency(\.claudeClient) var claudeClient
     @Dependency(\.acpClient) var acpClient
+    @Dependency(\.date.now) var now
 
     public init() {}
 
@@ -153,18 +166,9 @@ public struct CuttleFeature {
                 state.pendingContext = nil  // always clear; glow is drag-only
 
                 if let pending {
-                    // Collapse chat when re-docking via drag
-                    if wasExpanded { state.isExpanded = false }
-
-                    if pending != state.currentContext && !state.chatMessages.isEmpty {
-                        // Show transition alert
-                        state.alertPendingContext = pending
-                        state.showContextTransitionAlert = true
-                        state.mood = .transitioning
-                        snapToDropZone(state: &state, context: pending)
-                    } else {
-                        return switchContextSilently(state: &state, to: pending)
-                    }
+                    // Always open chat when docking
+                    state.isExpanded = true
+                    return switchContextSilently(state: &state, to: pending)
                 } else {
                     state.mood = .idle
                     if !wasExpanded {
@@ -206,38 +210,6 @@ public struct CuttleFeature {
                 state.isExpanded = false
                 return .none
 
-            // MARK: - Context Transition
-
-            case .contextTransitionConfirmed(let carry):
-                guard let pending = state.alertPendingContext else { return .none }
-                state.showContextTransitionAlert = false
-                state.alertPendingContext = nil
-
-                // Cancel any in-flight AI request to prevent cross-contamination
-                let cancelEffect = Effect<Action>.cancel(id: CancelID.aiRequest)
-                state.isLoading = false
-
-                let saveEffect: Effect<Action>
-                if !carry {
-                    saveEffect = saveChatHistory(state: &state)
-                } else {
-                    saveEffect = .none
-                }
-
-                let newContext = pending
-                state.currentContext = newContext
-                state.acpSentSystemPrompt = false
-                state.mood = .idle
-
-                if !carry {
-                    loadChatHistory(state: &state)
-                }
-                return .merge(cancelEffect, saveEffect, .send(.delegate(.contextChanged(newContext))))
-
-            case .cancelContextTransition:
-                // Dismissing the CTA defaults to "Start Fresh"
-                return .send(.contextTransitionConfirmed(carry: false))
-
             case .switchContext(let context):
                 return switchContextSilently(state: &state, to: context)
 
@@ -247,11 +219,14 @@ public struct CuttleFeature {
                 let rawInput = text.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !rawInput.isEmpty else { return .none }
 
+                ensureActiveSession(state: &state)
                 state.chatMessages.append(ChatMessage(role: .user, content: rawInput))
                 state.chatInput = ""
                 state.isLoading = true
                 state.error = nil
                 state.mood = .thinking
+                state.inFlightContext = state.currentContext
+                state.inFlightSessionID = state.activeSessionID
 
                 // Build system prompt using history BEFORE the just-appended user message,
                 // since the user message is sent separately in the messages array.
@@ -296,41 +271,53 @@ public struct CuttleFeature {
                 }
 
             case .aiResponseReceived(.success(let (text, usage, actionBlock))):
+                state.inFlightContext = nil
+                state.inFlightSessionID = nil
                 state.isLoading = false
                 state.mood = .idle
-                if !text.isEmpty {
-                    state.chatMessages.append(ChatMessage(role: .assistant, content: text))
-                }
                 state.tokenUsage = AITokenUsage(
                     inputTokens: state.tokenUsage.inputTokens + usage.inputTokens,
                     outputTokens: state.tokenUsage.outputTokens + usage.outputTokens
                 )
-                let saveEffect = saveChatHistory(state: &state)
 
-                // If actions were received and we're in a job context, delegate to parent
+                if !text.isEmpty {
+                    state.chatMessages.append(ChatMessage(role: .assistant, content: text))
+                }
+                let saveEffect = saveChatHistory(state: &state)
+                let titleEffect = maybeGenerateSessionTitle(state: &state)
+
+                var effects: [Effect<Action>] = [saveEffect]
+                if let titleEffect { effects.append(titleEffect) }
+
                 if let block = actionBlock, !block.actions.isEmpty,
                    case .job = state.currentContext {
-                    return .merge(
-                        saveEffect,
-                        .send(.delegate(.agentActionsReceived(block.actions, block.summary)))
-                    )
+                    effects.append(.send(.delegate(.agentActionsReceived(block.actions, block.summary))))
                 }
-                return saveEffect
+                return .merge(effects)
 
             case .aiResponseReceived(.failure(let error)):
+                state.inFlightContext = nil
+                state.inFlightSessionID = nil
                 state.isLoading = false
                 state.mood = .idle
                 state.error = "\(type(of: error)): \(error.localizedDescription)"
-                // Save the dangling user message so it isn't lost on context switch
                 return saveChatHistory(state: &state)
 
             case .clearChat:
+                // Cancel any in-flight request so its response doesn't land in the new session
+                let cancelEffect = Effect<Action>.cancel(id: CancelID.aiRequest)
+                // Archive current session (if non-empty) and start fresh
+                let archiveEffect = saveChatHistory(state: &state)
+                state.activeSessionID = nil
                 state.chatMessages = []
                 state.chatInput = ""
                 state.error = nil
                 state.tokenUsage = .zero
                 state.acpSentSystemPrompt = false
-                return saveChatHistory(state: &state)
+                state.isLoading = false
+                state.inFlightContext = nil
+                state.inFlightSessionID = nil
+                return .merge(cancelEffect, archiveEffect)
 
             case .applySuggestion(let prompt):
                 state.chatInput = prompt
@@ -338,15 +325,82 @@ public struct CuttleFeature {
 
             // MARK: - Lifecycle
 
-            case .restoreFromSettings(let context, let globalHistory, let statusHistories):
+            case .restoreFromSettings(let context, let globalSessions, let statusSessions):
                 state.currentContext = context
-                state.globalChatHistory = globalHistory
-                state.statusChatHistories = statusHistories
+                state.globalChatSessions = globalSessions
+                state.statusChatSessions = statusSessions
                 loadChatHistory(state: &state)
                 return .none
 
             case .positionAtDropZone:
                 snapToDropZone(state: &state, context: state.currentContext)
+                return .none
+
+            // MARK: - Sessions
+
+            case .toggleSessionSidebar:
+                state.isSessionSidebarVisible.toggle()
+                return .none
+
+            case .selectSession(let id):
+                // Save current session, then load selected
+                syncCurrentSessionMessages(state: &state)
+                let sessions = currentSessions(state: state)
+                if let session = sessions.first(where: { $0.id == id }) {
+                    state.chatMessages = session.messages
+                    state.activeSessionID = id
+                    state.tokenUsage = .zero
+                    state.error = nil
+                    state.acpSentSystemPrompt = false
+                }
+                return saveSessions(state: &state)
+
+            case .deleteSession(let id):
+                // Cancel in-flight request if it belongs to the session being deleted
+                var cancelEffect: Effect<Action> = .none
+                if id == state.inFlightSessionID {
+                    cancelEffect = .cancel(id: CancelID.aiRequest)
+                    state.isLoading = false
+                    state.inFlightContext = nil
+                    state.inFlightSessionID = nil
+                }
+
+                let sessions = currentSessions(state: state)
+                if id == state.activeSessionID {
+                    // Switch to an adjacent session before deleting
+                    if let idx = sessions.firstIndex(where: { $0.id == id }) {
+                        let nextIdx = idx > 0 ? idx - 1 : (sessions.count > 1 ? idx + 1 : nil)
+                        if let nextIdx {
+                            let next = sessions[nextIdx]
+                            state.chatMessages = next.messages
+                            state.activeSessionID = next.id
+                        } else {
+                            // Last session; clear everything
+                            state.chatMessages = []
+                            state.activeSessionID = nil
+                        }
+                    }
+                }
+                state.tokenUsage = .zero
+                state.error = nil
+                state.acpSentSystemPrompt = false
+                removeSession(state: &state, id: id)
+                return .merge(cancelEffect, saveSessions(state: &state))
+
+            case .sessionTitleGenerated(let sessionID, let title):
+                // Write the generated title into the session wherever it lives
+                let trimmed = String(title.trimmingCharacters(in: .whitespacesAndNewlines).prefix(40))
+                if let idx = state.globalChatSessions.firstIndex(where: { $0.id == sessionID }) {
+                    state.globalChatSessions[idx].generatedTitle = trimmed
+                }
+                for (key, sessions) in state.statusChatSessions {
+                    if let idx = sessions.firstIndex(where: { $0.id == sessionID }) {
+                        state.statusChatSessions[key]?[idx].generatedTitle = trimmed
+                    }
+                }
+                if let idx = state.activeJobSessions.firstIndex(where: { $0.id == sessionID }) {
+                    state.activeJobSessions[idx].generatedTitle = trimmed
+                }
                 return .none
 
             case .delegate:
@@ -367,9 +421,12 @@ public struct CuttleFeature {
     }
 
     private func switchContextSilently(state: inout State, to context: CuttleContext) -> Effect<Action> {
-        // Cancel any in-flight AI request to prevent cross-contamination
+        // Cancel any in-flight AI request to avoid cross-context contamination
         let cancelEffect = Effect<Action>.cancel(id: CancelID.aiRequest)
         state.isLoading = false
+        state.inFlightContext = nil
+        state.inFlightSessionID = nil
+        state.isExpanded = true
 
         // Save current history before switching
         let saveEffect = saveChatHistory(state: &state)
@@ -406,38 +463,230 @@ public struct CuttleFeature {
         }
     }
 
-    /// Saves chat messages to the appropriate history store, with pruning.
-    /// Returns a delegate effect for job-context so AppFeature can persist to the job model.
-    private func saveChatHistory(state: inout State) -> Effect<Action> {
-        let pruned = Array(state.chatMessages.suffix(Self.maxHistoryMessages))
+    // MARK: - Session Helpers
 
+    /// Maximum sessions retained per context.
+    private static let maxSessions = 50
+    /// Maximum sessions retained globally across all contexts.
+    private static let maxGlobalSessions = 200
+
+    /// Returns the display name for the current AI provider.
+    private func resolveAgentName(state: State) -> String? {
+        if state.acpConnection.aiProvider == .acpAgent {
+            return state.acpConnection.connectedAgentName
+        }
+        return nil
+    }
+
+    /// Returns the sessions array for the current context.
+    private func currentSessions(state: State) -> [ChatSession] {
         switch state.currentContext {
         case .global:
-            state.globalChatHistory = pruned
-            return .none
+            return state.globalChatSessions
         case .status(let status):
-            state.statusChatHistories[status.rawValue] = pruned
-            return .none
-        case .job(let id):
-            // Notify AppFeature to write chat back to the job model
-            return .send(.delegate(.jobChatUpdated(id, pruned)))
+            return state.statusChatSessions[status.rawValue] ?? []
+        case .job:
+            return state.activeJobSessions
         }
     }
 
-    private func loadChatHistory(state: inout State) {
+    /// Time gap (in seconds) after which a new session is started automatically.
+    private static let sessionIdleThreshold: TimeInterval = 3600  // 1 hour
+
+    /// Ensures an active session exists. Starts a new one if there is no active
+    /// session, or if the last message was more than 1 hour ago.
+    private func ensureActiveSession(state: inout State) {
+        let agentName = resolveAgentName(state: state)
+        let providerType = state.acpConnection.aiProvider
+
+        if let activeID = state.activeSessionID,
+           let session = currentSessions(state: state).first(where: { $0.id == activeID }) {
+            // Start a new session if the conversation has been idle for over an hour
+            let lastActivity = session.lastMessageAt
+            if now.timeIntervalSince(lastActivity) > Self.sessionIdleThreshold {
+                syncCurrentSessionMessages(state: &state)
+                startNewSession(state: &state, providerType: providerType, agentName: agentName)
+            }
+        } else {
+            startNewSession(state: &state, providerType: providerType, agentName: agentName)
+        }
+    }
+
+    /// Writes chatMessages back into the active session in the correct sessions array.
+    private func syncCurrentSessionMessages(state: inout State) {
+        guard let activeID = state.activeSessionID else { return }
+        let pruned = Array(state.chatMessages.suffix(Self.maxHistoryMessages))
+        let lastMessageAt = pruned.last?.timestamp ?? now
+
+        mutateCurrentSessions(state: &state) { sessions in
+            if let idx = sessions.firstIndex(where: { $0.id == activeID }) {
+                sessions[idx].messages = pruned
+                sessions[idx].lastMessageAt = lastMessageAt
+            }
+        }
+    }
+
+    /// Creates a new session, appends it to the current context, and sets it active.
+    private func startNewSession(state: inout State, providerType: AIProvider, agentName: String? = nil) {
+        let session = ChatSession(providerType: providerType, agentName: agentName, createdAt: now, lastMessageAt: now)
+        state.activeSessionID = session.id
+        state.chatMessages = []
+
+        mutateCurrentSessions(state: &state) { sessions in
+            sessions.append(session)
+            // Prune oldest sessions
+            if sessions.count > Self.maxSessions {
+                sessions = Array(sessions.suffix(Self.maxSessions))
+            }
+        }
+    }
+
+    /// Removes a session by ID from the current context's sessions array.
+    private func removeSession(state: inout State, id: UUID) {
+        mutateCurrentSessions(state: &state) { sessions in
+            sessions.removeAll { $0.id == id }
+        }
+    }
+
+    /// Mutates the sessions array for the current context in place.
+    private func mutateCurrentSessions(state: inout State, _ transform: (inout [ChatSession]) -> Void) {
         switch state.currentContext {
         case .global:
-            state.chatMessages = state.globalChatHistory
+            transform(&state.globalChatSessions)
         case .status(let status):
-            state.chatMessages = state.statusChatHistories[status.rawValue] ?? []
-        case .job(let id):
-            if let job = state.jobs.first(where: { $0.id == id }) {
-                state.chatMessages = job.chatHistory
-            } else {
-                state.chatMessages = []
+            var sessions = state.statusChatSessions[status.rawValue] ?? []
+            transform(&sessions)
+            state.statusChatSessions[status.rawValue] = sessions
+        case .job:
+            transform(&state.activeJobSessions)
+        }
+    }
+
+    /// Saves current chat session to the appropriate store.
+    /// Returns a delegate effect for job-context so AppFeature can persist to the job model.
+    private func saveChatHistory(state: inout State) -> Effect<Action> {
+        syncCurrentSessionMessages(state: &state)
+        pruneGlobalSessions(state: &state)
+        return saveSessions(state: &state)
+    }
+
+    /// Prunes oldest sessions globally (across global + status contexts) when the
+    /// total exceeds the global cap. Job sessions are excluded since they are
+    /// managed per-job and persisted separately.
+    private func pruneGlobalSessions(state: inout State) {
+        var total = state.globalChatSessions.count
+        for (_, sessions) in state.statusChatSessions {
+            total += sessions.count
+        }
+        guard total > Self.maxGlobalSessions else { return }
+
+        // Collect all sessions with their location, sorted by lastMessageAt
+        struct SessionRef: Comparable {
+            let lastMessageAt: Date
+            let id: UUID
+            let isGlobal: Bool
+            let statusKey: String?
+            static func < (lhs: SessionRef, rhs: SessionRef) -> Bool {
+                lhs.lastMessageAt < rhs.lastMessageAt
             }
+        }
+        var refs: [SessionRef] = []
+        for s in state.globalChatSessions {
+            refs.append(SessionRef(lastMessageAt: s.lastMessageAt, id: s.id, isGlobal: true, statusKey: nil))
+        }
+        for (key, sessions) in state.statusChatSessions {
+            for s in sessions {
+                refs.append(SessionRef(lastMessageAt: s.lastMessageAt, id: s.id, isGlobal: false, statusKey: key))
+            }
+        }
+        refs.sort()
+
+        // Remove oldest until we are at the cap, but never remove the active session
+        let toRemove = total - Self.maxGlobalSessions
+        var removed = 0
+        for ref in refs where removed < toRemove {
+            guard ref.id != state.activeSessionID else { continue }
+            if ref.isGlobal {
+                state.globalChatSessions.removeAll { $0.id == ref.id }
+            } else if let key = ref.statusKey {
+                state.statusChatSessions[key]?.removeAll { $0.id == ref.id }
+            }
+            removed += 1
+        }
+    }
+
+    /// Persists the sessions array for the current context.
+    private func saveSessions(state: inout State) -> Effect<Action> {
+        switch state.currentContext {
+        case .global, .status:
+            return .none
+        case .job(let id):
+            return .send(.delegate(.jobChatUpdated(id, state.activeJobSessions)))
+        }
+    }
+
+    /// Loads the most recent session for the current context into chatMessages.
+    private func loadChatHistory(state: inout State) {
+        // For job contexts, copy sessions into local buffer
+        if case .job(let id) = state.currentContext {
+            state.activeJobSessions = state.jobs.first(where: { $0.id == id })?.chatSessions ?? []
+        }
+
+        let sessions = currentSessions(state: state)
+        if let last = sessions.last {
+            state.chatMessages = last.messages
+            state.activeSessionID = last.id
+        } else {
+            state.chatMessages = []
+            state.activeSessionID = nil
         }
         state.tokenUsage = .zero
         state.error = nil
+    }
+
+    // MARK: - Session Title Generation
+
+    /// Number of user messages needed before requesting a title.
+    private static let titleTriggerCount = 3
+
+    /// If the active session has enough user messages and no title yet, fires a
+    /// background LLM call to generate one. Returns nil if no call is needed.
+    private func maybeGenerateSessionTitle(state: inout State) -> Effect<Action>? {
+        guard let activeID = state.activeSessionID else { return nil }
+        let sessions = currentSessions(state: state)
+        guard let session = sessions.first(where: { $0.id == activeID }) else { return nil }
+
+        // Already has a title, or not enough user messages yet
+        if session.generatedTitle != nil { return nil }
+        let userMessages = state.chatMessages.filter { $0.role == .user }
+        guard userMessages.count >= Self.titleTriggerCount else { return nil }
+
+        let snippets = userMessages.prefix(Self.titleTriggerCount).map { $0.content }
+        let sessionID = activeID
+        let apiKey = state.apiKey
+        let useACP = state.acpConnection.aiProvider == .acpAgent && state.acpConnection.isConnected
+
+        if useACP {
+            let prompt = Self.titlePrompt(for: snippets)
+            return .run { send in
+                let (text, _) = try await acpClient.sendPrompt(prompt, [])
+                await send(.sessionTitleGenerated(sessionID, text))
+            } catch: { _, _ in }
+            .cancellable(id: CancelID.titleGeneration, cancelInFlight: true)
+        } else if !apiKey.isEmpty {
+            let systemPrompt = "You name chat sessions. Respond with only a short title (2-4 words), nothing else."
+            let messages = [ChatMessage(role: .user, content: Self.titlePrompt(for: snippets))]
+            return .run { send in
+                let (text, _, _) = try await claudeClient.chat(apiKey, systemPrompt, messages, false)
+                await send(.sessionTitleGenerated(sessionID, text))
+            } catch: { _, _ in }
+            .cancellable(id: CancelID.titleGeneration, cancelInFlight: true)
+        }
+        return nil
+    }
+
+    private static func titlePrompt(for userMessages: [String]) -> String {
+        let numbered = userMessages.enumerated().map { "\($0.offset + 1). \($0.element)" }.joined(separator: "\n")
+        return "Give this chat session a short title (2-4 words). Only respond with the title, nothing else.\n\nUser messages:\n\(numbered)"
     }
 }

--- a/Sources/JobApplicationWizardCore/Features/Cuttle/CuttleOnboardingFeature.swift
+++ b/Sources/JobApplicationWizardCore/Features/Cuttle/CuttleOnboardingFeature.swift
@@ -61,11 +61,12 @@ public struct CuttleOnboardingFeature {
         case discoverAgent
         case connectAgent
         case meetCuttle
+        case dragToDock
         case expandCollapse
         case chatBasics
-        case dragToDock
-        case carryOrFresh
+        case sessions
         case resize
+        case collapseChat
 
         public var title: String {
             switch self {
@@ -75,8 +76,9 @@ public struct CuttleOnboardingFeature {
             case .expandCollapse: return "Expand / Collapse"
             case .chatBasics: return "Chat Basics"
             case .dragToDock: return "Drag to Dock"
-            case .carryOrFresh: return "Carry or Fresh"
+            case .sessions: return "Chat Sessions"
             case .resize: return "Resize"
+            case .collapseChat: return "Double-Click to Collapse"
             }
         }
 
@@ -89,15 +91,17 @@ public struct CuttleOnboardingFeature {
             case .meetCuttle:
                 return "This is Cuttle, your AI job search companion. It lives in your workspace and adapts to what you're working on."
             case .expandCollapse:
-                return "Double-click to open the chat window. Double-click again, press Escape, or click outside to close it."
+                return "Docking opens the chat automatically. Double-click to collapse, or press Escape, or click outside."
             case .chatBasics:
                 return "Type a question or click a suggestion chip. Cuttle's answers are scoped to its current context."
             case .dragToDock:
                 return "Drag Cuttle onto any status column, job card, or the All filter to change its context."
-            case .carryOrFresh:
-                return "When switching context with an active conversation, Cuttle asks whether to carry the conversation or start fresh."
+            case .sessions:
+                return "Each context keeps its own chat sessions. Toggle the sidebar to browse past conversations or start a new one."
             case .resize:
                 return "Drag the corner handle to resize the chat window."
+            case .collapseChat:
+                return "Double-click Cuttle to collapse the chat. Press Escape or click outside to close it too."
             }
         }
 
@@ -109,8 +113,9 @@ public struct CuttleOnboardingFeature {
             case .expandCollapse: return .blob
             case .chatBasics: return .chatWindow
             case .dragToDock: return .dockTargets
-            case .carryOrFresh: return .none
+            case .sessions: return .chatWindow
             case .resize: return .chatWindow
+            case .collapseChat: return .blob
             }
         }
     }
@@ -145,6 +150,8 @@ public struct CuttleOnboardingFeature {
             case dismissed
             case expandCuttle
             case collapseCuttle
+            case showSessionSidebar
+            case hideSessionSidebar
             case agentConnected(agentId: String, agentName: String)
         }
     }
@@ -232,36 +239,65 @@ public struct CuttleOnboardingFeature {
                 let steps = state.steps
                 let currentIndex = state.currentStepIndex
                 if currentIndex < steps.count - 1 {
-                    let nextStep = steps[currentIndex + 1]
-                    state.currentStep = nextStep
-                    // Auto-expand Cuttle when reaching chatBasics or resize
-                    if nextStep == .chatBasics || nextStep == .resize {
-                        return .send(.delegate(.expandCuttle))
+                    let leaving = steps[currentIndex]
+                    let entering = steps[currentIndex + 1]
+                    state.currentStep = entering
+
+                    var effects: [Effect<Action>] = []
+
+                    // Hide sidebar when leaving sessions (unless re-entering it)
+                    if leaving == .sessions && entering != .sessions {
+                        effects.append(.send(.delegate(.hideSessionSidebar)))
                     }
-                    // Collapse when leaving chatBasics/resize
-                    if steps[currentIndex] == .chatBasics || steps[currentIndex] == .resize {
-                        return .send(.delegate(.collapseCuttle))
+
+                    let chatSteps: Set<OnboardingStep> = [.chatBasics, .sessions, .resize]
+                    let leavingChat = chatSteps.contains(leaving)
+                    let enteringChat = chatSteps.contains(entering)
+
+                    if enteringChat && !leavingChat {
+                        effects.append(.send(.delegate(.expandCuttle)))
+                    } else if !enteringChat && leavingChat {
+                        effects.append(.send(.delegate(.collapseCuttle)))
                     }
+
+                    if entering == .sessions {
+                        effects.append(.send(.delegate(.showSessionSidebar)))
+                    }
+
+                    return effects.isEmpty ? .none : .merge(effects)
                 } else {
                     return .send(.finish)
                 }
-                return .none
 
             case .previousStep:
                 let steps = state.steps
                 let currentIndex = state.currentStepIndex
                 if currentIndex > 0 {
-                    let prevStep = steps[currentIndex - 1]
-                    // Collapse when leaving chatBasics/resize
-                    if state.currentStep == .chatBasics || state.currentStep == .resize {
-                        state.currentStep = prevStep
-                        return .send(.delegate(.collapseCuttle))
+                    let leaving = steps[currentIndex]
+                    let entering = steps[currentIndex - 1]
+                    state.currentStep = entering
+
+                    var effects: [Effect<Action>] = []
+
+                    if leaving == .sessions && entering != .sessions {
+                        effects.append(.send(.delegate(.hideSessionSidebar)))
                     }
-                    state.currentStep = prevStep
-                    // Expand when going back to chatBasics or resize
-                    if prevStep == .chatBasics || prevStep == .resize {
-                        return .send(.delegate(.expandCuttle))
+
+                    let chatSteps: Set<OnboardingStep> = [.chatBasics, .sessions, .resize]
+                    let leavingChat = chatSteps.contains(leaving)
+                    let enteringChat = chatSteps.contains(entering)
+
+                    if enteringChat && !leavingChat {
+                        effects.append(.send(.delegate(.expandCuttle)))
+                    } else if !enteringChat && leavingChat {
+                        effects.append(.send(.delegate(.collapseCuttle)))
                     }
+
+                    if entering == .sessions {
+                        effects.append(.send(.delegate(.showSessionSidebar)))
+                    }
+
+                    return effects.isEmpty ? .none : .merge(effects)
                 }
                 return .none
 

--- a/Tests/JobApplicationWizardTests/CuttleFeatureTests.swift
+++ b/Tests/JobApplicationWizardTests/CuttleFeatureTests.swift
@@ -114,27 +114,27 @@ final class CuttleFeatureTests: XCTestCase {
         XCTAssertNil(store.state.pendingContext)
     }
 
-    func testDragEndedShowsAlertWithActiveChat() async {
+    func testDragEndedSwitchesContextSilentlyWithActiveChat() async {
         var state = CuttleFeature.State()
         state.isDragging = true
         state.pendingContext = .status(.rejected)
         state.currentContext = .global
         state.chatMessages = [ChatMessage(role: .user, content: "Hello")]
         let store = TestStore(initialState: state) { CuttleFeature() }
+        store.exhaustivity = .off
 
-        await store.send(.dragEnded(CGPoint(x: 100, y: 100))) {
-            $0.isDragging = false
-            $0.pendingContext = nil
-            $0.alertPendingContext = .status(.rejected)
-            $0.showContextTransitionAlert = true
-            $0.mood = .transitioning
-        }
+        await store.send(.dragEnded(CGPoint(x: 100, y: 100)))
+
+        XCTAssertFalse(store.state.isDragging)
+        XCTAssertNil(store.state.pendingContext)
+        XCTAssertTrue(store.state.isExpanded)
+        XCTAssertEqual(store.state.currentContext, .status(.rejected))
     }
 
-    func testDragEndedCollapsesWhenExpanded() async {
+    func testDragEndedExpandsWhenDocking() async {
         var state = CuttleFeature.State()
         state.isDragging = true
-        state.isExpanded = true
+        state.isExpanded = false
         state.pendingContext = .global
         state.currentContext = .global
         state.chatMessages = []
@@ -143,7 +143,7 @@ final class CuttleFeatureTests: XCTestCase {
 
         await store.send(.dragEnded(CGPoint(x: 100, y: 100)))
 
-        XCTAssertFalse(store.state.isExpanded)
+        XCTAssertTrue(store.state.isExpanded)
     }
 
     func testDragEndedClampsWhenNoPendingContext() async {
@@ -161,89 +161,35 @@ final class CuttleFeatureTests: XCTestCase {
         }
     }
 
-    // MARK: - Context Transition (carry / fresh)
-
-    func testContextTransitionCarryKeepsMessages() async {
-        var state = CuttleFeature.State()
-        state.alertPendingContext = .status(.interview)
-        state.showContextTransitionAlert = true
-        state.currentContext = .global
-        state.chatMessages = [ChatMessage(role: .user, content: "Hello")]
-        state.isLoading = true
-        let store = TestStore(initialState: state) { CuttleFeature() }
-        store.exhaustivity = .off
-
-        await store.send(.contextTransitionConfirmed(carry: true))
-
-        XCTAssertEqual(store.state.currentContext, .status(.interview))
-        XCTAssertFalse(store.state.showContextTransitionAlert)
-        XCTAssertNil(store.state.alertPendingContext)
-        XCTAssertFalse(store.state.isLoading)
-        // Messages carried over
-        XCTAssertEqual(store.state.chatMessages.count, 1)
-        XCTAssertEqual(store.state.chatMessages[0].content, "Hello")
-    }
-
-    func testContextTransitionFreshLoadsNewHistory() async {
-        var state = CuttleFeature.State()
-        state.alertPendingContext = .status(.interview)
-        state.showContextTransitionAlert = true
-        state.currentContext = .global
-        state.chatMessages = [ChatMessage(role: .user, content: "Old message")]
-        state.globalChatHistory = []
-        state.statusChatHistories = ["Interview": [ChatMessage(role: .user, content: "Prev interview chat")]]
-        let store = TestStore(initialState: state) { CuttleFeature() }
-        store.exhaustivity = .off
-
-        await store.send(.contextTransitionConfirmed(carry: false))
-
-        XCTAssertEqual(store.state.currentContext, .status(.interview))
-        // Old message was saved to global, new history loaded
-        XCTAssertEqual(store.state.globalChatHistory.count, 1)
-        XCTAssertEqual(store.state.globalChatHistory[0].content, "Old message")
-        XCTAssertEqual(store.state.chatMessages.count, 1)
-        XCTAssertEqual(store.state.chatMessages[0].content, "Prev interview chat")
-    }
-
-    func testCancelContextTransitionDefaultsToStartFresh() async {
-        var state = CuttleFeature.State()
-        state.alertPendingContext = .status(.interview)
-        state.showContextTransitionAlert = true
-        state.currentContext = .global
-        state.dropZones = [
-            DropZone(id: "global", frame: CGRect(x: 50, y: 50, width: 100, height: 40), context: .global)
-        ]
-        let store = TestStore(initialState: state) { CuttleFeature() }
-        store.exhaustivity = .off
-
-        await store.send(.cancelContextTransition)
-
-        // cancelContextTransition now defaults to "Start Fresh" (carry: false)
-        await store.receive(\.contextTransitionConfirmed)
-
-        XCTAssertEqual(store.state.currentContext, .status(.interview))
-        XCTAssertFalse(store.state.showContextTransitionAlert)
-    }
-
     // MARK: - Switch Context (silent)
 
     func testSwitchContextSavesAndLoadsHistory() async {
+        let interviewSession = ChatSession(
+            providerType: .claudeAPI,
+            messages: [ChatMessage(role: .assistant, content: "Interview msg")]
+        )
         var state = CuttleFeature.State()
         state.currentContext = .global
         state.chatMessages = [ChatMessage(role: .user, content: "Global msg")]
-        state.statusChatHistories = ["Interview": [ChatMessage(role: .assistant, content: "Interview msg")]]
-        let store = TestStore(initialState: state) { CuttleFeature() }
+        state.activeSessionID = UUID()
+        state.globalChatSessions = [ChatSession(id: state.activeSessionID!, providerType: .claudeAPI, messages: state.chatMessages)]
+        state.statusChatSessions = ["Interview": [interviewSession]]
+        let store = TestStore(initialState: state) {
+            CuttleFeature()
+        } withDependencies: {
+            $0.date = .constant(Date())
+        }
         store.exhaustivity = .off
 
         await store.send(.switchContext(.status(.interview)))
 
-        // Old messages saved to global
-        XCTAssertEqual(store.state.globalChatHistory.count, 1)
-        XCTAssertEqual(store.state.globalChatHistory[0].content, "Global msg")
-        // New messages loaded from interview
+        // Session synced for global context
+        XCTAssertEqual(store.state.globalChatSessions.count, 1)
+        XCTAssertEqual(store.state.globalChatSessions[0].messages[0].content, "Global msg")
+        // Interview session loaded
+        XCTAssertEqual(store.state.currentContext, .status(.interview))
         XCTAssertEqual(store.state.chatMessages.count, 1)
         XCTAssertEqual(store.state.chatMessages[0].content, "Interview msg")
-        XCTAssertEqual(store.state.currentContext, .status(.interview))
         XCTAssertFalse(store.state.acpSentSystemPrompt)
     }
 
@@ -251,7 +197,11 @@ final class CuttleFeatureTests: XCTestCase {
         var state = CuttleFeature.State()
         state.currentContext = .global
         state.isLoading = true
-        let store = TestStore(initialState: state) { CuttleFeature() }
+        let store = TestStore(initialState: state) {
+            CuttleFeature()
+        } withDependencies: {
+            $0.date = .constant(Date())
+        }
         store.exhaustivity = .off
 
         await store.send(.switchContext(.status(.offer)))
@@ -268,6 +218,7 @@ final class CuttleFeatureTests: XCTestCase {
         let store = TestStore(initialState: state) {
             CuttleFeature()
         } withDependencies: {
+            $0.date = .constant(Date())
             $0.claudeClient.chat = { _, _, _, _ in
                 ("AI response", AITokenUsage(inputTokens: 10, outputTokens: 20), nil)
             }
@@ -298,6 +249,7 @@ final class CuttleFeatureTests: XCTestCase {
         let store = TestStore(initialState: state) {
             CuttleFeature()
         } withDependencies: {
+            $0.date = .constant(Date())
             $0.claudeClient.chat = { _, _, _, _ in
                 ("Response", AITokenUsage(inputTokens: 50, outputTokens: 75), nil)
             }
@@ -317,6 +269,7 @@ final class CuttleFeatureTests: XCTestCase {
         let store = TestStore(initialState: state) {
             CuttleFeature()
         } withDependencies: {
+            $0.date = .constant(Date())
             $0.claudeClient.chat = { _, _, _, _ in throw AIError.noAPIKey }
         }
         store.exhaustivity = .off
@@ -326,8 +279,8 @@ final class CuttleFeatureTests: XCTestCase {
 
         XCTAssertFalse(store.state.isLoading)
         XCTAssertNotNil(store.state.error)
-        // User message preserved in global history (via saveChatHistory on failure)
-        XCTAssertEqual(store.state.globalChatHistory.count, 1)
+        // User message preserved (session created on failure)
+        XCTAssertFalse(store.state.globalChatSessions.isEmpty)
     }
 
     // MARK: - AI Response with Job Context (delegate)
@@ -341,6 +294,7 @@ final class CuttleFeatureTests: XCTestCase {
         let store = TestStore(initialState: state) {
             CuttleFeature()
         } withDependencies: {
+            $0.date = .constant(Date())
             $0.claudeClient.chat = { _, _, _, _ in
                 ("AI response", AITokenUsage(inputTokens: 10, outputTokens: 20), nil)
             }
@@ -365,16 +319,20 @@ final class CuttleFeatureTests: XCTestCase {
         state.error = "some error"
         state.tokenUsage = AITokenUsage(inputTokens: 100, outputTokens: 200)
         state.acpSentSystemPrompt = true
-        let store = TestStore(initialState: state) { CuttleFeature() }
-
-        await store.send(.clearChat) {
-            $0.chatMessages = []
-            $0.chatInput = ""
-            $0.error = nil
-            $0.tokenUsage = .zero
-            $0.acpSentSystemPrompt = false
-            $0.globalChatHistory = []
+        let store = TestStore(initialState: state) {
+            CuttleFeature()
+        } withDependencies: {
+            $0.date = .constant(Date())
         }
+        store.exhaustivity = .off
+
+        await store.send(.clearChat)
+
+        XCTAssertTrue(store.state.chatMessages.isEmpty)
+        XCTAssertEqual(store.state.chatInput, "")
+        XCTAssertNil(store.state.error)
+        XCTAssertEqual(store.state.tokenUsage, .zero)
+        XCTAssertFalse(store.state.acpSentSystemPrompt)
     }
 
     // MARK: - Apply Suggestion
@@ -385,6 +343,7 @@ final class CuttleFeatureTests: XCTestCase {
         let store = TestStore(initialState: state) {
             CuttleFeature()
         } withDependencies: {
+            $0.date = .constant(Date())
             $0.claudeClient.chat = { _, _, _, _ in
                 ("Response", AITokenUsage(inputTokens: 10, outputTokens: 20), nil)
             }
@@ -403,32 +362,37 @@ final class CuttleFeatureTests: XCTestCase {
     // MARK: - Restore From Settings
 
     func testRestoreFromSettings() async {
-        let interviewMsg = ChatMessage(role: .assistant, content: "Interview chat")
-        let globalHistory = [ChatMessage(role: .user, content: "Saved")]
-        let statusHistories = ["Interview": [interviewMsg]]
+        let interviewSession = ChatSession(
+            providerType: .claudeAPI,
+            messages: [ChatMessage(role: .assistant, content: "Interview chat")]
+        )
+        let globalSessions: [ChatSession] = [ChatSession(
+            providerType: .claudeAPI,
+            messages: [ChatMessage(role: .user, content: "Saved")]
+        )]
+        let statusSessions = ["Interview": [interviewSession]]
         let store = TestStore(initialState: CuttleFeature.State()) { CuttleFeature() }
+        store.exhaustivity = .off
 
-        await store.send(.restoreFromSettings(.status(.interview), globalHistory, statusHistories)) {
-            $0.currentContext = .status(.interview)
-            $0.globalChatHistory = globalHistory
-            $0.statusChatHistories = statusHistories
-            $0.chatMessages = [interviewMsg]
-            $0.tokenUsage = .zero
-            $0.error = nil
-        }
+        await store.send(.restoreFromSettings(.status(.interview), globalSessions, statusSessions))
+
+        XCTAssertEqual(store.state.currentContext, .status(.interview))
+        XCTAssertEqual(store.state.globalChatSessions.count, 1)
+        XCTAssertEqual(store.state.statusChatSessions["Interview"]?.count, 1)
     }
 
     func testRestoreGlobalContext() async {
-        let globalHistory = [ChatMessage(role: .user, content: "Global msg")]
+        let globalSessions = [ChatSession(
+            providerType: .claudeAPI,
+            messages: [ChatMessage(role: .user, content: "Global msg")]
+        )]
         let store = TestStore(initialState: CuttleFeature.State()) { CuttleFeature() }
+        store.exhaustivity = .off
 
-        await store.send(.restoreFromSettings(.global, globalHistory, [:])) {
-            $0.currentContext = .global
-            $0.globalChatHistory = globalHistory
-            $0.chatMessages = globalHistory
-            $0.tokenUsage = .zero
-            $0.error = nil
-        }
+        await store.send(.restoreFromSettings(.global, globalSessions, [:]))
+
+        XCTAssertEqual(store.state.currentContext, .global)
+        XCTAssertEqual(store.state.globalChatSessions.count, 1)
     }
 
     // MARK: - Position At Drop Zone
@@ -474,46 +438,32 @@ final class CuttleFeatureTests: XCTestCase {
         }
     }
 
-    // MARK: - Chat History Pruning
-
-    func testSaveChatHistoryPrunesAt100Messages() async {
-        var state = CuttleFeature.State()
-        state.currentContext = .global
-        // Create 110 messages
-        state.chatMessages = (0..<110).map { i in
-            ChatMessage(role: .user, content: "Message \(i)")
-        }
-        let store = TestStore(initialState: state) { CuttleFeature() }
-
-        await store.send(.clearChat) {
-            $0.chatMessages = []
-            $0.chatInput = ""
-            $0.error = nil
-            $0.tokenUsage = .zero
-            $0.acpSentSystemPrompt = false
-            $0.globalChatHistory = []
-        }
-
-        // Verify pruning works by sending messages and checking saved history
-        // The clearChat above saves [] to globalChatHistory (pruned from 0).
-        // For a more direct test, let's switch context after filling messages.
-    }
+    // MARK: - Chat Session Persistence
 
     func testSavePrunesOnContextSwitch() async {
-        var state = CuttleFeature.State()
-        state.currentContext = .global
-        state.chatMessages = (0..<110).map { i in
+        let messages = (0..<110).map { i in
             ChatMessage(role: .user, content: "Message \(i)")
         }
-        let store = TestStore(initialState: state) { CuttleFeature() }
+        let session = ChatSession(providerType: .claudeAPI, messages: messages)
+        var state = CuttleFeature.State()
+        state.currentContext = .global
+        state.chatMessages = messages
+        state.activeSessionID = session.id
+        state.globalChatSessions = [session]
+        let store = TestStore(initialState: state) {
+            CuttleFeature()
+        } withDependencies: {
+            $0.date = .constant(Date())
+        }
         store.exhaustivity = .off
 
         await store.send(.switchContext(.status(.interview)))
 
-        // Global history should be pruned to last 100
-        XCTAssertEqual(store.state.globalChatHistory.count, 100)
-        XCTAssertEqual(store.state.globalChatHistory.first?.content, "Message 10")
-        XCTAssertEqual(store.state.globalChatHistory.last?.content, "Message 109")
+        // Messages within the session should be pruned to 100
+        XCTAssertEqual(store.state.globalChatSessions.count, 1)
+        XCTAssertEqual(store.state.globalChatSessions[0].messages.count, 100)
+        XCTAssertEqual(store.state.globalChatSessions[0].messages.first?.content, "Message 10")
+        XCTAssertEqual(store.state.globalChatSessions[0].messages.last?.content, "Message 109")
     }
 
     // MARK: - CuttleContext Properties
@@ -621,5 +571,413 @@ final class CuttleFeatureTests: XCTestCase {
         // Should contain truncated version (300 chars + "...")
         XCTAssertTrue(prompt.contains("..."))
         XCTAssertFalse(prompt.contains(longMessage))
+    }
+
+    // MARK: - Session Creation
+
+    func testSendMessageCreatesSessionAutomatically() async {
+        var state = CuttleFeature.State()
+        state.apiKey = "test-key"
+        let store = TestStore(initialState: state) {
+            CuttleFeature()
+        } withDependencies: {
+            $0.date = .constant(Date())
+            $0.claudeClient.chat = { _, _, _, _ in
+                ("Response", AITokenUsage(inputTokens: 10, outputTokens: 20), nil)
+            }
+        }
+        store.exhaustivity = .off
+
+        XCTAssertNil(store.state.activeSessionID)
+        XCTAssertTrue(store.state.globalChatSessions.isEmpty)
+
+        await store.send(.sendMessage("Hello"))
+        await store.receive(\.aiResponseReceived)
+
+        // A session should have been created and set as active
+        XCTAssertNotNil(store.state.activeSessionID)
+        XCTAssertEqual(store.state.globalChatSessions.count, 1)
+        XCTAssertEqual(store.state.globalChatSessions[0].id, store.state.activeSessionID)
+    }
+
+    func testIdleSessionCreatesNewOnSend() async {
+        // Create a session with a lastMessageAt over an hour ago
+        let oldDate = Date(timeIntervalSinceNow: -7200)
+        let oldSession = ChatSession(
+            providerType: .claudeAPI,
+            messages: [ChatMessage(role: .user, content: "Old msg")],
+            lastMessageAt: oldDate
+        )
+        var state = CuttleFeature.State()
+        state.apiKey = "test-key"
+        state.globalChatSessions = [oldSession]
+        state.activeSessionID = oldSession.id
+        state.chatMessages = oldSession.messages
+        let store = TestStore(initialState: state) {
+            CuttleFeature()
+        } withDependencies: {
+            $0.claudeClient.chat = { _, _, _, _ in
+                ("Response", AITokenUsage(inputTokens: 10, outputTokens: 20), nil)
+            }
+            $0.date = .constant(Date())
+        }
+        store.exhaustivity = .off
+
+        await store.send(.sendMessage("New message after long idle"))
+        await store.receive(\.aiResponseReceived)
+
+        // Should have created a second session (old one preserved, new one active)
+        XCTAssertEqual(store.state.globalChatSessions.count, 2)
+        XCTAssertNotEqual(store.state.activeSessionID, oldSession.id)
+    }
+
+    // MARK: - Session Selection
+
+    func testSelectSessionSwitchesActiveSession() async {
+        let session1 = ChatSession(
+            providerType: .claudeAPI,
+            messages: [ChatMessage(role: .user, content: "Session 1")]
+        )
+        let session2 = ChatSession(
+            providerType: .claudeAPI,
+            messages: [ChatMessage(role: .user, content: "Session 2")]
+        )
+        var state = CuttleFeature.State()
+        state.globalChatSessions = [session1, session2]
+        state.activeSessionID = session1.id
+        state.chatMessages = session1.messages
+        let store = TestStore(initialState: state) { CuttleFeature() }
+        store.exhaustivity = .off
+
+        await store.send(.selectSession(session2.id))
+
+        XCTAssertEqual(store.state.activeSessionID, session2.id)
+        XCTAssertEqual(store.state.chatMessages.count, 1)
+        XCTAssertEqual(store.state.chatMessages[0].content, "Session 2")
+    }
+
+    // MARK: - Session Deletion
+
+    func testDeleteSessionFallsBackToAdjacentSession() async {
+        let session1 = ChatSession(
+            providerType: .claudeAPI,
+            messages: [ChatMessage(role: .user, content: "Session 1")]
+        )
+        let session2 = ChatSession(
+            providerType: .claudeAPI,
+            messages: [ChatMessage(role: .user, content: "Session 2")]
+        )
+        var state = CuttleFeature.State()
+        state.globalChatSessions = [session1, session2]
+        state.activeSessionID = session2.id
+        state.chatMessages = session2.messages
+        let store = TestStore(initialState: state) { CuttleFeature() }
+        store.exhaustivity = .off
+
+        await store.send(.deleteSession(session2.id))
+
+        // Should fall back to session1
+        XCTAssertEqual(store.state.activeSessionID, session1.id)
+        XCTAssertEqual(store.state.chatMessages[0].content, "Session 1")
+        XCTAssertEqual(store.state.globalChatSessions.count, 1)
+    }
+
+    func testDeleteLastSessionClearsChat() async {
+        let session = ChatSession(
+            providerType: .claudeAPI,
+            messages: [ChatMessage(role: .user, content: "Only session")]
+        )
+        var state = CuttleFeature.State()
+        state.globalChatSessions = [session]
+        state.activeSessionID = session.id
+        state.chatMessages = session.messages
+        let store = TestStore(initialState: state) { CuttleFeature() }
+        store.exhaustivity = .off
+
+        await store.send(.deleteSession(session.id))
+
+        XCTAssertNil(store.state.activeSessionID)
+        XCTAssertTrue(store.state.chatMessages.isEmpty)
+        XCTAssertTrue(store.state.globalChatSessions.isEmpty)
+    }
+
+    // MARK: - Session Sidebar
+
+    func testToggleSessionSidebar() async {
+        let store = TestStore(initialState: CuttleFeature.State()) { CuttleFeature() }
+
+        await store.send(.toggleSessionSidebar) {
+            $0.isSessionSidebarVisible = true
+        }
+
+        await store.send(.toggleSessionSidebar) {
+            $0.isSessionSidebarVisible = false
+        }
+    }
+
+    // MARK: - Title Generation
+
+    func testSessionTitleGeneratedWritesTitle() async {
+        let session = ChatSession(
+            providerType: .claudeAPI,
+            messages: [ChatMessage(role: .user, content: "Test")]
+        )
+        var state = CuttleFeature.State()
+        state.globalChatSessions = [session]
+        state.activeSessionID = session.id
+        let store = TestStore(initialState: state) { CuttleFeature() }
+
+        await store.send(.sessionTitleGenerated(session.id, "  My Chat Title  ")) {
+            $0.globalChatSessions[0].generatedTitle = "My Chat Title"
+        }
+    }
+
+    func testSessionTitleGeneratedTruncatesAt40Chars() async {
+        let session = ChatSession(
+            providerType: .claudeAPI,
+            messages: [ChatMessage(role: .user, content: "Test")]
+        )
+        var state = CuttleFeature.State()
+        state.globalChatSessions = [session]
+        let store = TestStore(initialState: state) { CuttleFeature() }
+
+        let longTitle = String(repeating: "A", count: 60)
+        await store.send(.sessionTitleGenerated(session.id, longTitle)) {
+            $0.globalChatSessions[0].generatedTitle = String(repeating: "A", count: 40)
+        }
+    }
+
+    // MARK: - Context Switch Cancels In-Flight
+
+    func testContextSwitchClearsInFlightState() async {
+        var state = CuttleFeature.State()
+        state.currentContext = .global
+        state.isLoading = true
+        state.inFlightContext = .global
+        state.inFlightSessionID = UUID()
+        let store = TestStore(initialState: state) {
+            CuttleFeature()
+        } withDependencies: {
+            $0.date = .constant(Date())
+        }
+        store.exhaustivity = .off
+
+        await store.send(.switchContext(.status(.offer)))
+
+        XCTAssertFalse(store.state.isLoading)
+        XCTAssertNil(store.state.inFlightContext)
+        XCTAssertNil(store.state.inFlightSessionID)
+        XCTAssertEqual(store.state.currentContext, .status(.offer))
+    }
+
+    // MARK: - Per-Context Session Pruning
+
+    func testStartNewSessionPrunesWhenOverLimit() async {
+        // Fill global sessions to 55 with old timestamps so idle threshold triggers new session
+        let oldDate = Date(timeIntervalSinceNow: -7200)
+        var state = CuttleFeature.State()
+        state.apiKey = "test-key"
+        state.currentContext = .global
+        state.globalChatSessions = (0..<55).map { i in
+            ChatSession(
+                providerType: .claudeAPI,
+                messages: [ChatMessage(role: .user, content: "Session \(i)")],
+                lastMessageAt: oldDate
+            )
+        }
+        state.activeSessionID = state.globalChatSessions.last?.id
+        state.chatMessages = state.globalChatSessions.last?.messages ?? []
+        let store = TestStore(initialState: state) {
+            CuttleFeature()
+        } withDependencies: {
+            $0.date = .constant(Date())
+            $0.claudeClient.chat = { _, _, _, _ in
+                ("Response", AITokenUsage(inputTokens: 10, outputTokens: 20), nil)
+            }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.sendMessage("New session trigger"))
+        await store.receive(\.aiResponseReceived)
+
+        // Old session synced + new session created, but pruned to 50
+        XCTAssertLessThanOrEqual(store.state.globalChatSessions.count, 50)
+    }
+
+    // MARK: - Legacy Migration
+
+    func testLegacyChatHistoryMigratesToSession() throws {
+        // Simulate old JSON with chatHistory key
+        let oldJSON = """
+        {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "company": "Acme",
+            "title": "Engineer",
+            "status": "Wishlist",
+            "dateAdded": 0,
+            "updatedAt": 0,
+            "chatHistory": [
+                {"id": "00000000-0000-0000-0000-000000000002", "role": "user", "content": "Hello", "timestamp": 0},
+                {"id": "00000000-0000-0000-0000-000000000003", "role": "assistant", "content": "Hi!", "timestamp": 1}
+            ]
+        }
+        """
+        let data = oldJSON.data(using: .utf8)!
+        let job = try JSONDecoder().decode(JobApplication.self, from: data)
+
+        XCTAssertEqual(job.chatSessions.count, 1)
+        XCTAssertEqual(job.chatSessions[0].messages.count, 2)
+        XCTAssertEqual(job.chatSessions[0].providerName, "Claude API")
+        XCTAssertEqual(job.chatSessions[0].providerType, .claudeAPI)
+        XCTAssertEqual(job.chatSessions[0].messages[0].content, "Hello")
+        XCTAssertEqual(job.chatSessions[0].messages[1].content, "Hi!")
+    }
+
+    func testLegacyEmptyChatHistoryMigratesToEmptySessions() throws {
+        let oldJSON = """
+        {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "company": "Acme",
+            "title": "Engineer",
+            "status": "Wishlist",
+            "dateAdded": 0,
+            "updatedAt": 0,
+            "chatHistory": []
+        }
+        """
+        let data = oldJSON.data(using: .utf8)!
+        let job = try JSONDecoder().decode(JobApplication.self, from: data)
+
+        XCTAssertTrue(job.chatSessions.isEmpty)
+    }
+
+    // MARK: - Global Pruning
+
+    func testPruneGlobalSessionsEvictsOldestWhenOverCap() async {
+        var state = CuttleFeature.State()
+        state.currentContext = .global
+        // Create 210 global sessions (cap is 200), each with a distinct timestamp
+        let baseDate = Date(timeIntervalSinceReferenceDate: 0)
+        state.globalChatSessions = (0..<210).map { i in
+            ChatSession(
+                providerType: .claudeAPI,
+                messages: [ChatMessage(role: .user, content: "Msg \(i)")],
+                createdAt: baseDate.addingTimeInterval(Double(i)),
+                lastMessageAt: baseDate.addingTimeInterval(Double(i))
+            )
+        }
+        // Set active to the newest so it's protected from eviction
+        state.activeSessionID = state.globalChatSessions.last?.id
+        state.chatMessages = [ChatMessage(role: .user, content: "Active msg")]
+
+        let store = TestStore(initialState: state) {
+            CuttleFeature()
+        } withDependencies: {
+            $0.date = .constant(Date())
+        }
+        store.exhaustivity = .off
+
+        // switchContext triggers saveChatHistory which calls pruneGlobalSessions
+        await store.send(.switchContext(.status(.interview)))
+
+        // Should be pruned to 200
+        XCTAssertLessThanOrEqual(store.state.globalChatSessions.count, 200)
+        // The active session should be preserved
+        XCTAssertTrue(store.state.globalChatSessions.contains(where: { $0.id == state.activeSessionID }))
+        // The oldest sessions should have been removed
+        XCTAssertFalse(store.state.globalChatSessions.contains(where: { $0.messages.first?.content == "Msg 0" }))
+    }
+
+    func testMessagePruningWithinSessionCapsAt100() async {
+        var state = CuttleFeature.State()
+        state.currentContext = .global
+        state.apiKey = "test-key"
+        // Create a session with 110 messages
+        let session = ChatSession(
+            providerType: .claudeAPI,
+            messages: (0..<110).map { ChatMessage(role: .user, content: "Msg \($0)") }
+        )
+        state.globalChatSessions = [session]
+        state.activeSessionID = session.id
+        state.chatMessages = session.messages
+
+        let store = TestStore(initialState: state) {
+            CuttleFeature()
+        } withDependencies: {
+            $0.date = .constant(Date())
+        }
+        store.exhaustivity = .off
+
+        // switchContext triggers saveChatHistory -> syncCurrentSessionMessages which prunes
+        await store.send(.switchContext(.status(.interview)))
+
+        // The saved global session should be pruned to 100 messages
+        if let savedSession = store.state.globalChatSessions.first(where: { $0.id == session.id }) {
+            XCTAssertEqual(savedSession.messages.count, 100)
+            XCTAssertEqual(savedSession.messages.first?.content, "Msg 10")
+            XCTAssertEqual(savedSession.messages.last?.content, "Msg 109")
+        } else {
+            XCTFail("Session should still exist after context switch")
+        }
+    }
+
+    // MARK: - Delete In-Flight Session
+
+    func testDeleteInFlightSessionCancelsRequest() async {
+        let session = ChatSession(
+            providerType: .claudeAPI,
+            messages: [ChatMessage(role: .user, content: "Pending")]
+        )
+        var state = CuttleFeature.State()
+        state.globalChatSessions = [session]
+        state.activeSessionID = session.id
+        state.chatMessages = session.messages
+        state.isLoading = true
+        state.inFlightSessionID = session.id
+        state.inFlightContext = .global
+        let store = TestStore(initialState: state) { CuttleFeature() }
+        store.exhaustivity = .off
+
+        await store.send(.deleteSession(session.id))
+
+        XCTAssertFalse(store.state.isLoading)
+        XCTAssertNil(store.state.inFlightSessionID)
+        XCTAssertNil(store.state.inFlightContext)
+        XCTAssertTrue(store.state.globalChatSessions.isEmpty)
+    }
+
+    // MARK: - ChatSession Model
+
+    func testProviderNameComputedFromType() {
+        let claudeSession = ChatSession(providerType: .claudeAPI)
+        XCTAssertEqual(claudeSession.providerName, "Claude API")
+
+        let acpSession = ChatSession(providerType: .acpAgent)
+        XCTAssertEqual(acpSession.providerName, "ACP Agent")
+
+        let namedACP = ChatSession(providerType: .acpAgent, agentName: "My Custom Agent")
+        XCTAssertEqual(namedACP.providerName, "My Custom Agent")
+    }
+
+    func testLegacySettingsChatHistoryMigratesToSessions() throws {
+        let oldJSON = """
+        {
+            "globalChatHistory": [
+                {"id": "00000000-0000-0000-0000-000000000001", "role": "user", "content": "Global msg", "timestamp": 0}
+            ],
+            "statusChatHistories": {
+                "Interview": [
+                    {"id": "00000000-0000-0000-0000-000000000002", "role": "assistant", "content": "Interview msg", "timestamp": 0}
+                ]
+            }
+        }
+        """
+        let data = oldJSON.data(using: .utf8)!
+        let settings = try JSONDecoder().decode(AppSettings.self, from: data)
+
+        XCTAssertEqual(settings.globalChatSessions.count, 1)
+        XCTAssertEqual(settings.globalChatSessions[0].messages[0].content, "Global msg")
+        XCTAssertEqual(settings.statusChatSessions["Interview"]?.count, 1)
+        XCTAssertEqual(settings.statusChatSessions["Interview"]?[0].messages[0].content, "Interview msg")
     }
 }

--- a/Tests/JobApplicationWizardTests/CuttleOnboardingTests.swift
+++ b/Tests/JobApplicationWizardTests/CuttleOnboardingTests.swift
@@ -231,7 +231,7 @@ final class CuttleOnboardingTests: XCTestCase {
         let store = TestStore(initialState: state) { CuttleOnboardingFeature() }
 
         await store.send(.nextStep) {
-            $0.currentStep = .expandCollapse
+            $0.currentStep = .dragToDock
         }
     }
 
@@ -248,24 +248,24 @@ final class CuttleOnboardingTests: XCTestCase {
         await store.receive(\.delegate.expandCuttle)
     }
 
-    func testNextStepFromChatBasicsCollapsesCuttle() async {
+    func testNextStepFromChatBasicsGoesToSessions() async {
         var state = CuttleOnboardingFeature.State()
         state.isActive = true
         state.aiReady = true
         state.currentStep = .chatBasics
         let store = TestStore(initialState: state) { CuttleOnboardingFeature() }
+        store.exhaustivity = .off
 
         await store.send(.nextStep) {
-            $0.currentStep = .dragToDock
+            $0.currentStep = .sessions
         }
-        await store.receive(\.delegate.collapseCuttle)
     }
 
     func testNextStepOnLastStepFinishes() async {
         var state = CuttleOnboardingFeature.State()
         state.isActive = true
         state.aiReady = true
-        state.currentStep = .resize
+        state.currentStep = .collapseChat
         let store = TestStore(initialState: state) { CuttleOnboardingFeature() }
 
         await store.send(.nextStep)
@@ -281,12 +281,13 @@ final class CuttleOnboardingTests: XCTestCase {
         var state = CuttleOnboardingFeature.State()
         state.isActive = true
         state.aiReady = true
-        state.currentStep = .carryOrFresh
+        state.currentStep = .sessions
         let store = TestStore(initialState: state) { CuttleOnboardingFeature() }
 
         await store.send(.previousStep) {
-            $0.currentStep = .dragToDock
+            $0.currentStep = .chatBasics
         }
+        await store.receive(\.delegate.hideSessionSidebar)
     }
 
     func testPreviousStepAtFirstDoesNothing() async {
@@ -358,10 +359,10 @@ final class CuttleOnboardingTests: XCTestCase {
     func testStepCountWithAiReady() {
         var state = CuttleOnboardingFeature.State()
         state.aiReady = true
-        XCTAssertEqual(state.steps.count, 6)
+        XCTAssertEqual(state.steps.count, 7)
 
         state.aiReady = false
-        XCTAssertEqual(state.steps.count, 8)
+        XCTAssertEqual(state.steps.count, 9)
     }
 
     // MARK: - State Properties
@@ -379,7 +380,7 @@ final class CuttleOnboardingTests: XCTestCase {
     func testIsLastStep() {
         var state = CuttleOnboardingFeature.State()
         state.aiReady = true
-        state.currentStep = .resize
+        state.currentStep = .collapseChat
         XCTAssertTrue(state.isLastStep)
 
         state.currentStep = .meetCuttle

--- a/Tests/JobApplicationWizardTests/JSONRoundTripTests.swift
+++ b/Tests/JobApplicationWizardTests/JSONRoundTripTests.swift
@@ -15,7 +15,7 @@ final class JSONRoundTripTests: XCTestCase {
             labels: [JobLabel(name: "Remote", colorHex: "#34C759")],
             contacts: [Contact(name: "Alice", title: "Recruiter", email: "a@co.com", linkedin: "linkedin.com/alice")],
             interviews: [InterviewRound(round: 1, type: "Phone Screen", date: Date(), interviewers: "Bob")],
-            chatHistory: [ChatMessage(role: .user, content: "Help me prepare")],
+            chatSessions: [ChatSession(providerType: .claudeAPI, messages: [ChatMessage(role: .user, content: "Help me prepare")])],
             documents: [JobDocument(filename: "resume.pdf", documentType: .pdf, rawText: "Resume content", fileSize: 1024)],
             tasks: [SubTask(title: "Apply online", forStatus: .applied)]
         )
@@ -68,7 +68,7 @@ final class JSONRoundTripTests: XCTestCase {
         XCTAssertEqual(decodedJob.tasks.count, 1)
         XCTAssertEqual(decodedJob.tasks[0].forStatus, JobStatus.applied)
 
-        XCTAssertEqual(decodedJob.chatHistory.count, 1)
+        XCTAssertEqual(decodedJob.chatSessions.count, 1)
         XCTAssertEqual(decodedJob.documents.count, 1)
 
         // Verify settings

--- a/Tests/JobApplicationWizardTests/JobDetailFeatureTests.swift
+++ b/Tests/JobApplicationWizardTests/JobDetailFeatureTests.swift
@@ -568,25 +568,28 @@ final class JobDetailFeatureTests: XCTestCase {
         XCTAssertEqual(decoded.content, "Test response")
     }
 
-    func testJobApplicationChatHistoryRoundTrip() throws {
+    func testJobApplicationChatSessionsRoundTrip() throws {
         var job = JobApplication.mock()
-        job.chatHistory = [
-            ChatMessage(role: .user, content: "Hello"),
-            ChatMessage(role: .assistant, content: "Hi!"),
-        ]
+        job.chatSessions = [ChatSession(
+            providerType: .claudeAPI,
+            messages: [
+                ChatMessage(role: .user, content: "Hello"),
+                ChatMessage(role: .assistant, content: "Hi!"),
+            ]
+        )]
         let data = try JSONEncoder().encode(job)
         let decoded = try JSONDecoder().decode(JobApplication.self, from: data)
-        XCTAssertEqual(decoded.chatHistory.count, 2)
-        XCTAssertEqual(decoded.chatHistory[0].role, .user)
-        XCTAssertEqual(decoded.chatHistory[1].role, .assistant)
+        XCTAssertEqual(decoded.chatSessions.count, 1)
+        XCTAssertEqual(decoded.chatSessions[0].messages.count, 2)
+        XCTAssertEqual(decoded.chatSessions[0].messages[0].role, .user)
+        XCTAssertEqual(decoded.chatSessions[0].messages[1].role, .assistant)
     }
 
-    func testJobApplicationEmptyChatHistoryNotEncoded() throws {
+    func testJobApplicationEmptyChatSessionsNotEncoded() throws {
         let job = JobApplication.mock()
         let data = try JSONEncoder().encode(job)
         let json = String(data: data, encoding: .utf8)!
-        // Empty chatHistory should not be in JSON (we skip encoding it)
-        XCTAssertFalse(json.contains("chatHistory"))
+        XCTAssertFalse(json.contains("chatSessions"))
     }
 
     // MARK: - moveJobRequested

--- a/Tests/JobApplicationWizardTests/TestHelpers.swift
+++ b/Tests/JobApplicationWizardTests/TestHelpers.swift
@@ -24,7 +24,7 @@ extension JobApplication {
         excitement: Int = 3,
         hasPDF: Bool = false,
         pdfPath: String? = nil,
-        chatHistory: [ChatMessage] = [],
+        chatSessions: [ChatSession] = [],
         documents: [JobDocument] = [],
         tasks: [SubTask] = []
     ) -> JobApplication {
@@ -49,7 +49,7 @@ extension JobApplication {
         job.excitement = excitement
         job.hasPDF = hasPDF
         job.pdfPath = pdfPath
-        job.chatHistory = chatHistory
+        job.chatSessions = chatSessions
         job.documents = documents
         job.tasks = tasks
         return job


### PR DESCRIPTION
## Summary
- Replaces flat `chatHistory` arrays with a `ChatSession` model supporting multiple named sessions per context (global, per-status, per-job)
- Each session tracks provider type, optional agent name, messages, timestamps, and an LLM-generated title
- Legacy `chatHistory` data auto-migrates on decode via `LegacyCodingKeys`
- Removes the carry/fresh context transition alert; docking silently switches context since each context maintains its own session history
- Adds a session sidebar in CuttleView for browsing and creating sessions
- All shared model types now conform to `Sendable` for Swift 6 readiness

## Key design decisions
- In-flight AI requests are cancelled on context switch and session deletion (simpler than cross-context write-back)
- `providerName` is computed from `providerType` + optional `agentName` (no stored string drift)
- `@Dependency(\.date.now)` used throughout reducer for TCA determinism
- Session persistence triggered on `sendMessage`, `selectSession`, `deleteSession`, `sessionTitleGenerated`, `aiResponseReceived`, `clearChat`, and `switchContext`
- Per-context cap of 50 sessions, global cap of 200, 100 messages per session

## Test plan
- [x] 403 tests passing, 0 failures
- [x] Session auto-creation on first message
- [x] Idle threshold (1 hour) triggers new session
- [x] Session selection loads correct messages
- [x] Session deletion falls back to adjacent session
- [x] Deleting in-flight session cancels AI request
- [x] Per-context pruning caps at 50 sessions
- [x] Global pruning caps at 200 sessions (preserves active)
- [x] Message pruning caps at 100 per session
- [x] Legacy `chatHistory` migration (JobApplication and AppSettings)
- [x] Onboarding step sequence updated (sessions, collapseChat)
- [x] Title generation writes and truncates at 40 chars
- [x] Context switch clears in-flight state
- [x] Manual: verify session sidebar appears and sessions persist across relaunch
- [x] Manual: verify docking switches context silently with chat expanded


🤖 Generated with [Claude Code](https://claude.com/claude-code)