### PR TITLE
fix: show welcome screen once per app version

### DIFF
--- a/Sources/JobApplicationShared/Models.swift
+++ b/Sources/JobApplicationShared/Models.swift
@@ -456,6 +456,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
     // API key is stored in the system Keychain, not here.
     public var userProfile: UserProfile = UserProfile()
     public var defaultViewMode: ViewMode = .kanban
+    public var lastSeenOnboardingVersion: String? = nil
     public var aiProvider: AIProvider = .acpAgent
     public var selectedACPAgentId: String? = nil
     public var cuttleContext: CuttleContext? = nil
@@ -467,7 +468,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
     public var companyProfiles: [CompanyProfile] = []
 
     private enum CodingKeys: String, CodingKey {
-        case userProfile, defaultViewMode, aiProvider, selectedACPAgentId
+        case userProfile, defaultViewMode, lastSeenOnboardingVersion, aiProvider, selectedACPAgentId
         case cuttleContext, globalChatSessions, statusChatSessions
         case agentActionMode, autoProcessDocuments, hasCuttleOnboardingCompleted, companyProfiles
     }
@@ -484,6 +485,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         let legacy = try decoder.container(keyedBy: LegacyCodingKeys.self)
         userProfile          = try c.decodeIfPresent(UserProfile.self,            forKey: .userProfile)          ?? UserProfile()
         defaultViewMode      = try c.decodeIfPresent(ViewMode.self,               forKey: .defaultViewMode)      ?? .kanban
+        lastSeenOnboardingVersion = try c.decodeIfPresent(String.self,            forKey: .lastSeenOnboardingVersion)
         aiProvider           = try c.decodeIfPresent(AIProvider.self,             forKey: .aiProvider)           ?? .acpAgent
         selectedACPAgentId   = try c.decodeIfPresent(String.self,                 forKey: .selectedACPAgentId)
         cuttleContext        = try c.decodeIfPresent(CuttleContext.self,          forKey: .cuttleContext)

--- a/Sources/JobApplicationWizardCore/Dependencies/AppVersionClient.swift
+++ b/Sources/JobApplicationWizardCore/Dependencies/AppVersionClient.swift
@@ -1,0 +1,33 @@
+import Foundation
+import ComposableArchitecture
+
+public struct AppVersionClient {
+    public var currentVersion: @Sendable () -> String
+
+    public init(currentVersion: @escaping @Sendable () -> String) {
+        self.currentVersion = currentVersion
+    }
+}
+
+extension AppVersionClient: DependencyKey {
+    public static let liveValue = AppVersionClient(
+        currentVersion: {
+            Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+                ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+                ?? "1.0"
+        }
+    )
+}
+
+extension AppVersionClient: TestDependencyKey {
+    public static let testValue = AppVersionClient(
+        currentVersion: { "0.0" }
+    )
+}
+
+extension DependencyValues {
+    public var appVersionClient: AppVersionClient {
+        get { self[AppVersionClient.self] }
+        set { self[AppVersionClient.self] = newValue }
+    }
+}

--- a/Sources/JobApplicationWizardCore/Features/App/AppFeature.swift
+++ b/Sources/JobApplicationWizardCore/Features/App/AppFeature.swift
@@ -14,6 +14,7 @@ public struct AppFeature {
     @ObservableState
     public struct State: Equatable {
         public var jobs: IdentifiedArrayOf<JobApplication> = []
+        public var hasLoadedJobs: Bool = false
         public var selectedJobID: UUID? = nil
         public var searchQuery: String = ""
         public var filterStatus: JobStatus? = nil
@@ -102,6 +103,7 @@ public struct AppFeature {
         case importCSV
         case importCSVResult([JobApplication])
         case dismissOnboarding
+        case replayWelcomeScreen
         case saveSettingsKey(String)
         case showProfileTapped
         case dismissProfile
@@ -158,6 +160,7 @@ public struct AppFeature {
 
     @Dependency(\.persistenceClient) var persistence
     @Dependency(\.keychainClient) var keychain
+    @Dependency(\.appVersionClient) var appVersionClient
     @Dependency(\.acpClient) var acpClient
     @Dependency(\.acpRegistryClient) var acpRegistry
     @Dependency(\.historyClient) var historyClient
@@ -198,26 +201,28 @@ public struct AppFeature {
                 )
 
             case .jobsLoaded(.success(let jobs)):
+                state.hasLoadedJobs = true
                 state.jobs = IdentifiedArray(uniqueElements: jobs)
                 state.cuttle.jobs = Array(state.jobs)
-                if state.jobs.isEmpty {
-                    state.showOnboarding = true
-                }
                 return .none
 
             case .jobsLoaded(.failure(let error)):
+                state.hasLoadedJobs = true
                 state.saveError = "Failed to load jobs: \(error.localizedDescription). Your data file may be corrupted; check jobs.json or jobs.backup.json in Application Support."
                 return .none
 
             case .settingsLoaded(.success(let settings)):
+                let currentVersion = appVersionClient.currentVersion()
+                let shouldShowWelcome = state.hasLoadedJobs && settings.lastSeenOnboardingVersion != currentVersion
                 state.settings = settings
                 state.viewMode = settings.defaultViewMode
+                state.showOnboarding = shouldShowWelcome
                 state.$acpConnection.withLock { $0.aiProvider = settings.aiProvider }
                 // Restore Cuttle state from settings
                 state.cuttle.userProfile = settings.userProfile
                 let context = settings.cuttleContext ?? .global
                 // Trigger Cuttle onboarding if not completed and app onboarding is not showing
-                let shouldStartOnboarding = !settings.hasCuttleOnboardingCompleted && !state.showOnboarding
+                let shouldStartOnboarding = !settings.hasCuttleOnboardingCompleted && !shouldShowWelcome
                 if shouldStartOnboarding {
                     state.cuttleOnboarding.aiReady = state.acpConnection.isConnected || !state.claudeAPIKey.isEmpty
                     insertOnboardingDemoJob(state: &state)
@@ -235,6 +240,7 @@ public struct AppFeature {
             case .settingsLoaded(.failure):
                 state.settings = AppSettings()
                 state.viewMode = state.settings.defaultViewMode
+                state.showOnboarding = state.hasLoadedJobs
                 state.$acpConnection.withLock { $0.aiProvider = state.settings.aiProvider }
                 if state.settings.aiProvider == .acpAgent {
                     return .send(.fetchACPRegistry)
@@ -808,13 +814,22 @@ public struct AppFeature {
 
             case .dismissOnboarding:
                 state.showOnboarding = false
+                state.settings.lastSeenOnboardingVersion = appVersionClient.currentVersion()
                 // Start Cuttle onboarding if not yet completed
                 if !state.settings.hasCuttleOnboardingCompleted {
                     state.cuttleOnboarding.aiReady = state.acpConnection.isConnected || !state.claudeAPIKey.isEmpty
                     insertOnboardingDemoJob(state: &state)
-                    return .send(.cuttleOnboarding(.start))
+                    return .merge(
+                        saveSettings(state.settings),
+                        .send(.cuttleOnboarding(.start))
+                    )
                 }
-                return .none
+                return saveSettings(state.settings)
+
+            case .replayWelcomeScreen:
+                state.settings.lastSeenOnboardingVersion = nil
+                state.showOnboarding = true
+                return saveSettings(state.settings)
 
             case .saveSettingsKey(let key):
                 state.claudeAPIKey = key
@@ -847,7 +862,6 @@ public struct AppFeature {
                 state.jobs = []
                 state.selectedJobID = nil
                 state.jobDetail = nil
-                state.showOnboarding = true
                 state.cuttle.jobs = []
                 return saveJobs(state.jobs)
 

--- a/Sources/JobApplicationWizardCore/SettingsView.swift
+++ b/Sources/JobApplicationWizardCore/SettingsView.swift
@@ -78,6 +78,18 @@ private struct GeneralSettingsTab: View {
                     .font(DS.Typography.caption)
                     .foregroundColor(DS.Color.textSecondary)
             }
+
+            Section("Welcome") {
+                Button("Show Welcome Screen Again") {
+                    store.send(.replayWelcomeScreen)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Text("Reopen the welcome screen for this version.")
+                    .font(DS.Typography.caption)
+                    .foregroundColor(DS.Color.textSecondary)
+            }
         }
         .formStyle(.grouped)
         .padding(.horizontal, DS.Spacing.lg)

--- a/Tests/JobApplicationWizardTests/AppFeatureTests.swift
+++ b/Tests/JobApplicationWizardTests/AppFeatureTests.swift
@@ -13,6 +13,7 @@ final class AppFeatureTests: XCTestCase {
         let settings: AppSettings = {
             var s = AppSettings()
             s.userProfile.name = "Test"
+            s.lastSeenOnboardingVersion = "3.0.4"
             return s
         }()
 
@@ -24,6 +25,7 @@ final class AppFeatureTests: XCTestCase {
             $0.keychainClient.loadAPIKey = { "sk-test-key" }
             $0.keychainClient.saveAPIKey = { _ in }
             $0.acpRegistryClient = ACPRegistryClient(fetchAgents: { [] })
+            $0.appVersionClient.currentVersion = { "3.0.4" }
         }
 
         store.exhaustivity = .off
@@ -42,15 +44,56 @@ final class AppFeatureTests: XCTestCase {
         }
     }
 
-    func testEmptyJobsTriggersOnboarding() async {
+    func testNewVersionTriggersOnboardingEvenWhenJobsExist() async {
+        let jobs = [JobApplication.mock()]
+        let settings: AppSettings = {
+            var s = AppSettings()
+            s.lastSeenOnboardingVersion = "3.0.3"
+            return s
+        }()
+
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.persistenceClient.loadJobs = { jobs }
+            $0.persistenceClient.loadSettings = { settings }
+            $0.keychainClient.loadAPIKey = { "" }
+            $0.keychainClient.saveAPIKey = { _ in }
+            $0.acpRegistryClient = ACPRegistryClient(fetchAgents: { [] })
+            $0.appVersionClient.currentVersion = { "3.0.4" }
+        }
+
+        store.exhaustivity = .off
+
+        await store.send(.onAppear)
+        await store.receive(\.jobsLoaded) {
+            $0.jobs = IdentifiedArray(uniqueElements: jobs)
+        }
+        await store.receive(\.settingsLoaded) {
+            $0.settings = settings
+            $0.viewMode = settings.defaultViewMode
+            $0.$acpConnection.withLock { $0.aiProvider = settings.aiProvider }
+            $0.showOnboarding = true
+        }
+        await store.receive(\.saveSettingsKey)
+    }
+
+    func testMatchingVersionDoesNotTriggerOnboardingWhenJobsAreEmpty() async {
+        let settings: AppSettings = {
+            var s = AppSettings()
+            s.lastSeenOnboardingVersion = "3.0.4"
+            return s
+        }()
+
         let store = TestStore(initialState: AppFeature.State()) {
             AppFeature()
         } withDependencies: {
             $0.persistenceClient.loadJobs = { [] }
-            $0.persistenceClient.loadSettings = { AppSettings() }
+            $0.persistenceClient.loadSettings = { settings }
             $0.keychainClient.loadAPIKey = { "" }
             $0.keychainClient.saveAPIKey = { _ in }
             $0.acpRegistryClient = ACPRegistryClient(fetchAgents: { [] })
+            $0.appVersionClient.currentVersion = { "3.0.4" }
         }
 
         store.exhaustivity = .off
@@ -58,9 +101,12 @@ final class AppFeatureTests: XCTestCase {
         await store.send(.onAppear)
         await store.receive(\.jobsLoaded) {
             $0.jobs = []
-            $0.showOnboarding = true
         }
-        await store.receive(\.settingsLoaded)
+        await store.receive(\.settingsLoaded) {
+            $0.settings = settings
+            $0.viewMode = settings.defaultViewMode
+            $0.$acpConnection.withLock { $0.aiProvider = settings.aiProvider }
+        }
         await store.receive(\.saveSettingsKey)
     }
 
@@ -407,6 +453,39 @@ final class AppFeatureTests: XCTestCase {
             $0.jobs = []
             $0.selectedJobID = nil
             $0.jobDetail = nil
+        }
+    }
+
+    func testDismissOnboardingPersistsCurrentVersion() async {
+        var state = AppFeature.State()
+        state.showOnboarding = true
+        state.settings.hasCuttleOnboardingCompleted = true
+
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.persistenceClient.saveSettings = { _ in }
+            $0.appVersionClient.currentVersion = { "3.0.4" }
+        }
+
+        await store.send(.dismissOnboarding) {
+            $0.showOnboarding = false
+            $0.settings.lastSeenOnboardingVersion = "3.0.4"
+        }
+    }
+
+    func testReplayWelcomeScreenClearsStoredVersionAndShowsOnboarding() async {
+        var state = AppFeature.State()
+        state.settings.lastSeenOnboardingVersion = "3.0.4"
+
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.persistenceClient.saveSettings = { _ in }
+        }
+
+        await store.send(.replayWelcomeScreen) {
+            $0.settings.lastSeenOnboardingVersion = nil
             $0.showOnboarding = true
         }
     }
@@ -426,6 +505,7 @@ final class AppFeatureTests: XCTestCase {
             $0.keychainClient.loadAPIKey = { "" }
             $0.keychainClient.saveAPIKey = { _ in }
             $0.acpRegistryClient = ACPRegistryClient(fetchAgents: { [] })
+            $0.appVersionClient.currentVersion = { "3.0.4" }
         }
 
         store.exhaustivity = .off


### PR DESCRIPTION
## What
Show the welcome screen once per app version instead of on every launch. This also adds a Settings action to show it again on demand.

## Why
Right now the welcome screen comes back every time the app opens. That adds friction to normal use and makes the onboarding feel noisy instead of helpful. Showing it once per release keeps the update context visible without interrupting repeat launches.

## How
This stores the last app version that showed onboarding, compares it during launch, saves the current version when the screen is dismissed, and adds a Settings action that clears the stored version so the welcome screen can be reopened. I also added reducer coverage for the new launch and replay paths.

## Testing
- [x] `swift test` passes locally
- [x] Targeted launch-path tests pass locally
  - `swift test --package-path /Users/danhart/Developer/JobApplicationWizard --disable-automatic-resolution --filter AppFeatureTests`
  - `swift test --package-path /Users/danhart/Developer/JobApplicationWizard --disable-automatic-resolution --filter CalendarClientTests/testAppFeatureDoesNotRequestCalendarPermissionOnLaunch`
- [x] Tested in the app (not run locally)

## Screenshots
Not applicable.

## Checklist
- [x] Commits follow `type: description` convention
- [x] I have read CONTRIBUTING.md