### PR TITLE
build: drive iOS bundle ID and dev team via xcconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .build/
+.swiftpm/
 *.o
 *.d
 *.swp
@@ -16,4 +17,5 @@ commercial/
 default.profraw
 demo_data.json
 iOS/build/
+iOS/Config/Local.xcconfig
 Sources/JobApplicationShared/Secrets.swift

--- a/iOS/Config/Local.xcconfig.example
+++ b/iOS/Config/Local.xcconfig.example
@@ -1,0 +1,4 @@
+// Copy this file to Local.xcconfig and fill in your own values.
+// Local.xcconfig is gitignored and will not be committed.
+BUNDLE_ID_PREFIX = com.yourname
+DEVELOPMENT_TEAM = YOUR_TEAM_ID

--- a/iOS/Config/Shared.xcconfig
+++ b/iOS/Config/Shared.xcconfig
@@ -1,0 +1,4 @@
+// Upstream defaults. To use your own values, create Local.xcconfig (gitignored).
+BUNDLE_ID_PREFIX = com.zsparks
+DEVELOPMENT_TEAM = LS3NPGGCN7
+#include? "Local.xcconfig"

--- a/iOS/JobApplicationWizardiOS.xcodeproj/project.pbxproj
+++ b/iOS/JobApplicationWizardiOS.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 
 /* Begin PBXFileReference section */
 		0593A71C5F95A7A380907A8C /* WidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WidgetExtension.entitlements; sourceTree = "<group>"; };
+		1A699F807E1D8909DE94730B /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
 		217764F480A06FBCBA5E2407 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		27365E0C3E87AA93428B9867 /* QuickAddView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAddView.swift; sourceTree = "<group>"; };
 		2EE3C4B50E655B28989470A5 /* iOSAppFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSAppFeature.swift; sourceTree = "<group>"; };
@@ -43,7 +44,7 @@
 		4E53CBB04F1CCC27A28203D8 /* InterviewDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewDetailView.swift; sourceTree = "<group>"; };
 		554518668E49B6B3B23F177B /* SettingsViewiOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewiOS.swift; sourceTree = "<group>"; };
 		59ABE44C7342A51CC9514412 /* PipelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipelineView.swift; sourceTree = "<group>"; };
-		7F0D79B8CCE69BBDA4FD2F7D /* JobApplicationWizardiOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JobApplicationWizardiOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7F0D79B8CCE69BBDA4FD2F7D /* JobApplicationWizardiOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = JobApplicationWizardiOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AC1C543BBC07D40BC73E6A2 /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
 		94EE01D036F9547CF812D150 /* ShareJobExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = ShareJobExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		98BCE5002AC9DC4D1FDDF3DB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -94,6 +95,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		14C549E706A9C246152E50B2 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				1A699F807E1D8909DE94730B /* Shared.xcconfig */,
+			);
+			path = Config;
+			sourceTree = "<group>";
+		};
 		4BA3D1E20A646B48BE8B774F /* WidgetExtension */ = {
 			isa = PBXGroup;
 			children = (
@@ -191,6 +200,7 @@
 		E57B9D940A906155F228B35E = {
 			isa = PBXGroup;
 			children = (
+				14C549E706A9C246152E50B2 /* Config */,
 				89D5FAD0CCE77C884DA9F41D /* JobApplicationWizardiOS */,
 				760F4212DF08D7BF0FD03A07 /* Packages */,
 				4BB02AD74CB11DADAF18C32B /* ShareExtension */,
@@ -270,6 +280,17 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					37D35F63133000A78EFDBB6A = {
+						DevelopmentTeam = LS3NPGGCN7;
+					};
+					686B3FEC8A8DAFED5A49D3F7 = {
+						DevelopmentTeam = LS3NPGGCN7;
+					};
+					961197CBCCB3E315FC3810BC = {
+						DevelopmentTeam = LS3NPGGCN7;
+					};
+				};
 			};
 			buildConfigurationList = DF9DA82AC36EF8DDB5D0B535 /* Build configuration list for PBXProject "JobApplicationWizardiOS" */;
 			developmentRegion = en;
@@ -349,12 +370,12 @@
 /* Begin XCBuildConfiguration section */
 		19A74944DE274764D47AB360 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1A699F807E1D8909DE94730B /* Shared.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = JobApplicationWizardiOS/Resources/App.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = LS3NPGGCN7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = JobApplicationWizardiOS/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -366,7 +387,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zsparks.JobApplicationWizardiOS;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_ID_PREFIX).JobApplicationWizardiOS";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -438,6 +459,7 @@
 		};
 		324A1D55F79D72A0FE996B5A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1A699F807E1D8909DE94730B /* Shared.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = WidgetExtension/WidgetExtension.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
@@ -448,7 +470,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zsparks.JobApplicationWizardiOS.PipelineWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_ID_PREFIX).JobApplicationWizardiOS.PipelineWidget";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -457,6 +479,7 @@
 		};
 		926E2BF7E1868F369980AFF5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1A699F807E1D8909DE94730B /* Shared.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = WidgetExtension/WidgetExtension.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
@@ -467,7 +490,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zsparks.JobApplicationWizardiOS.PipelineWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_ID_PREFIX).JobApplicationWizardiOS.PipelineWidget";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -476,6 +499,7 @@
 		};
 		99544F3699C672ED01576228 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1A699F807E1D8909DE94730B /* Shared.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
@@ -487,7 +511,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zsparks.JobApplicationWizardiOS.ShareJobExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_ID_PREFIX).JobApplicationWizardiOS.ShareJobExtension";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -496,6 +520,7 @@
 		};
 		CE1D52410D9A745D5C60FBF5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1A699F807E1D8909DE94730B /* Shared.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
@@ -507,7 +532,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zsparks.JobApplicationWizardiOS.ShareJobExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_ID_PREFIX).JobApplicationWizardiOS.ShareJobExtension";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -516,12 +541,12 @@
 		};
 		E1D1DA2D47E30DBDECB44CE8 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1A699F807E1D8909DE94730B /* Shared.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = JobApplicationWizardiOS/Resources/App.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = LS3NPGGCN7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = JobApplicationWizardiOS/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -533,7 +558,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zsparks.JobApplicationWizardiOS;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_ID_PREFIX).JobApplicationWizardiOS";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/iOS/JobApplicationWizardiOS/Resources/App.entitlements
+++ b/iOS/JobApplicationWizardiOS/Resources/App.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.zsparks.JobApplicationWizard</string>
+		<string>group.$(BUNDLE_ID_PREFIX).JobApplicationWizard</string>
 	</array>
 </dict>
 </plist>

--- a/iOS/ShareExtension/ShareExtension.entitlements
+++ b/iOS/ShareExtension/ShareExtension.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.zsparks.JobApplicationWizard</string>
+		<string>group.$(BUNDLE_ID_PREFIX).JobApplicationWizard</string>
 	</array>
 </dict>
 </plist>

--- a/iOS/WidgetExtension/WidgetExtension.entitlements
+++ b/iOS/WidgetExtension/WidgetExtension.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.zsparks.JobApplicationWizard</string>
+		<string>group.$(BUNDLE_ID_PREFIX).JobApplicationWizard</string>
 	</array>
 </dict>
 </plist>

--- a/iOS/project.yml
+++ b/iOS/project.yml
@@ -20,7 +20,7 @@ targets:
       - path: JobApplicationWizardiOS/Resources/Assets.xcassets
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.zsparks.JobApplicationWizardiOS
+        PRODUCT_BUNDLE_IDENTIFIER: $(BUNDLE_ID_PREFIX).JobApplicationWizardiOS
         MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: 1
         GENERATE_INFOPLIST_FILE: YES
@@ -30,6 +30,9 @@ targets:
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ENTITLEMENTS: JobApplicationWizardiOS/Resources/App.entitlements
+    configFiles:
+      Debug: Config/Shared.xcconfig
+      Release: Config/Shared.xcconfig
     info:
       path: JobApplicationWizardiOS/Info.plist
       properties:
@@ -49,12 +52,15 @@ targets:
       - path: WidgetExtension
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.zsparks.JobApplicationWizardiOS.PipelineWidget
+        PRODUCT_BUNDLE_IDENTIFIER: $(BUNDLE_ID_PREFIX).JobApplicationWizardiOS.PipelineWidget
         MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: 1
         GENERATE_INFOPLIST_FILE: YES
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ENTITLEMENTS: WidgetExtension/WidgetExtension.entitlements
+    configFiles:
+      Debug: Config/Shared.xcconfig
+      Release: Config/Shared.xcconfig
     dependencies:
       - package: JobApplicationWizard
         product: JobApplicationShared
@@ -68,12 +74,15 @@ targets:
       - path: ShareExtension
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.zsparks.JobApplicationWizardiOS.ShareJobExtension
+        PRODUCT_BUNDLE_IDENTIFIER: $(BUNDLE_ID_PREFIX).JobApplicationWizardiOS.ShareJobExtension
         MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ENTITLEMENTS: ShareExtension/ShareExtension.entitlements
         INFOPLIST_KEY_CFBundleDisplayName: Save Job
+    configFiles:
+      Debug: Config/Shared.xcconfig
+      Release: Config/Shared.xcconfig
     dependencies:
       - package: JobApplicationWizard
         product: JobApplicationShared


### PR DESCRIPTION
## What
Replace hardcoded `com.zsparks` bundle IDs and `DEVELOPMENT_TEAM` in `project.yml` and entitlements with `$(BUNDLE_ID_PREFIX)` and a build setting sourced from `iOS/Config/Shared.xcconfig`.

## Why
Contributors building locally currently have to edit the tracked `project.yml` and entitlements to set their own bundle ID prefix and Apple Developer team, which pollutes every PR they open. With an xcconfig-driven default plus a gitignored `Local.xcconfig` override, local-only values stay out of the diff.

Also gitignore `.swiftpm/` (per-user SPM and workspace state).

## How
- `iOS/Config/Shared.xcconfig` (tracked) defines upstream defaults: `BUNDLE_ID_PREFIX = com.zsparks`, `DEVELOPMENT_TEAM = LS3NPGGCN7`. It optionally includes `Local.xcconfig` via `#include?`, so contributor overrides take precedence when present.
- `iOS/Config/Local.xcconfig.example` is a template; copying it to `Local.xcconfig` (gitignored) lets contributors set their own values.
- All three targets in `project.yml` reference `Config/Shared.xcconfig` through `configFiles`, and their `PRODUCT_BUNDLE_IDENTIFIER` values use `$(BUNDLE_ID_PREFIX).*`.
- The three entitlements files use `group.$(BUNDLE_ID_PREFIX).JobApplicationWizard` so the app group resolves alongside the bundle ID.
- Regenerated `iOS/JobApplicationWizardiOS.xcodeproj` with `xcodegen generate` to bake in the xcconfig references (CI uses the committed xcodeproj directly).

## Testing
- [x] `swift test` passes locally
- [x] Tested in the app: built and ran on a physical iPhone with a `Local.xcconfig` override (`com.izzynavedo` prefix, personal team ID); bundle ID and app group resolved correctly, Google Drive sync between macOS and iOS continued to work, widget and share extension built and signed.

## Screenshots
N/A; build configuration change with no UI impact.

## Checklist
- [x] Commits follow `type: description` convention
- [x] I have read CONTRIBUTING.md