### PR TITLE
build: copy root Info.plist into macOS app bundle

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -6,6 +6,8 @@
 	<string>Job Application Wizard</string>
 	<key>CFBundleExecutable</key>
 	<string>JobApplicationWizard</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.zsparks.jobapplicationwizard</string>
 	<key>CFBundleName</key>
@@ -20,6 +22,11 @@
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSCalendarsFullAccessUsageDescription</key>
 	<string>Job Application Wizard reads your calendar to let you tag existing events as interview rounds.</string>
 	<key>NSHighResolutionCapable</key>

--- a/build_dmg.sh
+++ b/build_dmg.sh
@@ -43,28 +43,7 @@ install_name_tool \
     -add_rpath "@loader_path/../Frameworks" \
     "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 
-cat > "$APP_BUNDLE/Contents/Info.plist" << INFOPLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>CFBundleExecutable</key><string>$APP_NAME</string>
-    <key>CFBundleIdentifier</key><string>$BUNDLE_ID</string>
-    <key>CFBundleName</key><string>Job Application Wizard</string>
-    <key>CFBundleDisplayName</key><string>Job Application Wizard</string>
-    <key>CFBundleVersion</key><string>$VERSION</string>
-    <key>CFBundleShortVersionString</key><string>$VERSION</string>
-    <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleIconFile</key><string>AppIcon</string>
-    <key>NSPrincipalClass</key><string>NSApplication</string>
-    <key>NSHighResolutionCapable</key><true/>
-    <key>LSMinimumSystemVersion</key><string>14.0</string>
-    <key>NSAppTransportSecurity</key><dict><key>NSAllowsArbitraryLoads</key><true/></dict>
-    <key>SUPublicEDKey</key><string>YY0EyAJ+Ce21J9m6kGnRDWaRGJSbLvnrStmrXLpiEto=</string>
-    <key>SUFeedURL</key><string>https://raw.githubusercontent.com/zacspa/JobApplicationWizard/main/appcast.xml</string>
-</dict>
-</plist>
-INFOPLIST
+cp Info.plist "$APP_BUNDLE/Contents/Info.plist"
 
 echo "▶ Signing app bundle (inside-out)..."
 SPARKLE_FW="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"


### PR DESCRIPTION
## What
Make the root `Info.plist` the single source of truth for the macOS `.app` bundle, so privacy usage descriptions and other keys actually ship.

## Why
`build_dmg.sh` generated a stripped-down `Info.plist` inline via heredoc instead of copying the tracked root `Info.plist`. The generated plist omitted `NSCalendarsFullAccessUsageDescription`, so on installed builds the macOS calendar permission prompt never appeared, `EKEventStore.requestFullAccessToEvents()` silently failed, and no entry was created in System Settings > Privacy & Security > Calendars. The "Link Calendar Event" affordance in interview rounds was effectively unreachable. `LSApplicationCategoryType` and `NSSupportsAutomaticGraphicsSwitching` were similarly being dropped.

## How
- Replace the heredoc in `build_dmg.sh:46-67` with `cp Info.plist "$APP_BUNDLE/Contents/Info.plist"`, so the bundle's `Info.plist` matches the tracked one.
- Add `CFBundleIconFile` and `NSAppTransportSecurity` to the root `Info.plist`; those were only in the old heredoc, so without them the icon and existing ATS behavior would regress.

Version updates via PlistBuddy earlier in the script (lines 19-22) still work; they now write to the same file that ends up in the bundle.

## Testing
- [x] `swift test` passes locally
- [x] Tested in the app: patched the existing installed bundle by adding `NSCalendarsFullAccessUsageDescription` via PlistBuddy and re-signing ad-hoc, then opened a job > interview round > "Link Calendar Event". The macOS calendar permission prompt appeared on first click, a Calendars entry was created under System Settings > Privacy & Security, and event linking succeeded. With the key missing (pre-patch), the prompt never appeared and the UI fell into the "Calendar access required in System Settings" branch.

## Screenshots
N/A; build script change. Behavioral fix is the OS-level permission prompt appearing on first link attempt.

## Checklist
- [x] Commits follow `type: description` convention
- [x] I have read CONTRIBUTING.md